### PR TITLE
simplify order's signature

### DIFF
--- a/src/main/scala/com/tinkerpop/gremlin/scala/GremlinScalaPipeline.scala
+++ b/src/main/scala/com/tinkerpop/gremlin/scala/GremlinScalaPipeline.scala
@@ -347,9 +347,13 @@ class GremlinScalaPipeline[S, E] extends GremlinPipeline[S, E] {
   def transform[T](function: E => T): GremlinScalaPipeline[S, T] = {
     super.transform(new ScalaPipeFunction(function)).asInstanceOf[GremlinScalaPipeline[S, T]]
   }
-  
-  def order[T](compareFunction: com.tinkerpop.pipes.util.structures.Pair[E,E] => JInteger): GremlinScalaPipeline[S, T] = {
-    super.order(new ScalaPipeFunction(compareFunction)).asInstanceOf[GremlinScalaPipeline[S, T]]
+
+  override def order: GremlinScalaPipeline[S, E] = {
+    super.order().asInstanceOf[GremlinScalaPipeline[S, E]]
+  }
+
+  def order(compareFunction: PipeFunction[TPair[E, E], Int]): GremlinScalaPipeline[S, E] = {
+    super.order({ x: TPair[E, E] => compareFunction.compute(x).asInstanceOf[JInteger] }).asInstanceOf[GremlinScalaPipeline[S, E]]
   }
   
   //////////////////////

--- a/src/test/scala/com/tinkerpop/gremlin/scala/transform/OrderStepTest.scala
+++ b/src/test/scala/com/tinkerpop/gremlin/scala/transform/OrderStepTest.scala
@@ -4,6 +4,7 @@ import com.tinkerpop.blueprints.impls.tg.TinkerGraphFactory
 import com.tinkerpop.gremlin.test.ComplianceTest
 import com.tinkerpop.gremlin.scala._
 import com.tinkerpop.blueprints.Vertex
+import com.tinkerpop.pipes.util.structures.{Pair => TPair}
 import java.lang.{Integer => JInteger}
 
 class OrderStepTest extends com.tinkerpop.gremlin.test.transform.OrderStepTest {
@@ -16,19 +17,16 @@ class OrderStepTest extends com.tinkerpop.gremlin.test.transform.OrderStepTest {
   def test_g_V_name_order() {
     super.test_g_V_name_order(g.V.property("name").order())
   }
-  
+
   def test_g_V_name_orderXabX() {
-	  super.test_g_V_name_orderXabX(g.V.property("name")
-	           .order({arg: com.tinkerpop.pipes.util.structures.Pair[String,String] => 
-	           		arg.getB.compareTo(arg.getA).asInstanceOf[JInteger]}))
+    super.test_g_V_name_orderXabX(g.V.property("name")
+      .order({arg: TPair[String, String] => arg.getB.compareTo(arg.getA)}))
   }
-  
+
   def test_g_V_orderXa_nameXb_nameX_name() {
-	  super.test_g_V_orderXa_nameXb_nameX_name(g.V
-	           .order({arg: com.tinkerpop.pipes.util.structures.Pair[Vertex,Vertex] => 
-	           		arg.getB.getProperty("name").asInstanceOf[String]
-	           			.compareTo(arg.getA.getProperty("name").asInstanceOf[String])
-	           			.asInstanceOf[JInteger]}).property("name"))
+    super.test_g_V_orderXa_nameXb_nameX_name(g.V
+      .order({ arg: TPair[Vertex, Vertex] => arg.getB.as[String]("name").get.compareTo(arg.getA.as[String]("name").get) })
+      .property("name").asInstanceOf[GremlinScalaPipeline[Vertex, String]])
   }
 
 }


### PR DESCRIPTION
This simplifies the comparison functions that the caller has to pass in when ordering.  Previously you'd have to pass in something like:

```
g.V.order({arg: TPair[String, String] =>
  arg.getB.compareTo(arg.getA).asInstanceOf[JInteger]
})
```

This change allows you to drop the `asInstanceOf[JInteger]`:

```
g.V.order({arg: TPair[String, String] =>
  arg.getB.compareTo(arg.getA)
})
```
