### PR TITLE
Calling transform generates a StackOverflowError exception

### DIFF
--- a/src/main/scala/com/tinkerpop/gremlin/scala/GremlinScalaPipeline.scala
+++ b/src/main/scala/com/tinkerpop/gremlin/scala/GremlinScalaPipeline.scala
@@ -350,7 +350,7 @@ class GremlinScalaPipeline[S, E] extends GremlinPipeline[S, E] with Dynamic {
   override def cap: GremlinScalaPipeline[S, _] = super.cap()
 
   def map[T](function: E ⇒ T): GremlinScalaPipeline[S, T] = super.transform(new ScalaPipeFunction(function))
-  def transform[T](function: E ⇒ T): GremlinScalaPipeline[S, T] = transform(function)
+  def transform[T](function: E ⇒ T): GremlinScalaPipeline[S, T] = map(function)
 
   override def order: GremlinScalaPipeline[S, E] = addPipe2(new OrderPipe)
   override def order(by: Order = Order.INCR): GremlinScalaPipeline[S, E] = addPipe2(new OrderPipe(by))


### PR DESCRIPTION
Calling transform generates the following exception:
java.lang.StackOverflowError: null
    at com.tinkerpop.gremlin.scala.GremlinScalaPipeline.transform(GremlinScalaPipeline.scala:343) ~[gremlin-scala-2.4.1.jar:na]
    at com.tinkerpop.gremlin.scala.GremlinScalaPipeline.transform(GremlinScalaPipeline.scala:343) ~[gremlin-scala-2.4.1.jar:na]
    at com.tinkerpop.gremlin.scala.GremlinScalaPipeline.transform(GremlinScalaPipeline.scala:343) ~[gremlin-scala-2.4.1.jar:na]
    at com.tinkerpop.gremlin.scala.GremlinScalaPipeline.transform(GremlinScalaPipeline.scala:343) ~[gremlin-scala-2.4.1.jar:na]
    at com.tinkerpop.gremlin.scala.GremlinScalaPipeline.transform(GremlinScalaPipeline.scala:343) ~[gremlin-scala-2.4.1.jar:na]
    at com.tinkerpop.gremlin.scala.GremlinScalaPipeline.transform(GremlinScalaPipeline.scala:343) ~[gremlin-scala-2.4.1.jar:na]

Shouldn't it be map instead of transform here?
