### PR TITLE
Make tests more robust to changes in iteration order.

### DIFF
--- a/src/test/scala/com/tinkerpop/gremlin/scala/transform/ScatterStepTest.scala
+++ b/src/test/scala/com/tinkerpop/gremlin/scala/transform/ScatterStepTest.scala
@@ -13,18 +13,18 @@ import com.tinkerpop.gremlin.scala._
 class ScatterStepTest extends FunSpec with ShouldMatchers with TestGraph {
 
   it("uses scatter to unroll elements that have been gathered before") {
-    val pipe = graph.v(1).out.map(_.getProperty[String]("name")).gather.scatter
+    val pipe = graph.v(1).out.map(_.getProperty[String]("name")).order.gather.scatter
 
     val first = pipe.next()
-    first should be("vadas")
+    first should be("josh")
     pipe.hasNext should be(true)
 
     val second = pipe.next()
-    second should be("josh")
+    second should be("lop")
     pipe.hasNext should be(true)
 
     val third = pipe.next()
-    third should be("lop")
+    third should be("vadas")
     pipe.hasNext should be(false)
   }
 

--- a/src/test/scala/com/tinkerpop/gremlin/scala/transform/TraversalStepsTest.scala
+++ b/src/test/scala/com/tinkerpop/gremlin/scala/transform/TraversalStepsTest.scala
@@ -14,13 +14,19 @@ class TraversalStepsTest extends FunSpec with ShouldMatchers with TestGraph {
     }
 
     it("gets the out vertices") {
-      graph.v(1).out.property("name").toSet should be(Set("vadas", "josh", "lop"))
-      graph.v(1).out(1).property("name").toSet should be(Set("vadas"))
+      val outNames = Set("vadas", "josh", "lop")
+      graph.v(1).out.property("name").toSet should be(outNames)
+      val resultsLimited = graph.v(1).out(1).property("name").toList
+      resultsLimited.size should be(1)
+      outNames.intersect(resultsLimited.toSet).size should be(1)
     }
 
     it("gets the in vertices") {
-      graph.v(3).in.property("name").toSet should be(Set("marko", "josh", "peter"))
-      graph.v(3).in(1).property("name").toSet should be(Set("marko"))
+      val inNames = Set("marko", "josh", "peter")
+      graph.v(3).in.property("name").toSet should be(inNames)
+      val resultsLimited = graph.v(3).in(1).property("name").toList
+      resultsLimited.size should be(1)
+      inNames.intersect(resultsLimited.toSet).size should be(1)
     }
 
     it("gets both in and out vertices") {
@@ -35,8 +41,11 @@ class TraversalStepsTest extends FunSpec with ShouldMatchers with TestGraph {
     }
 
     it("follows out edges") {
-      graph.v(1).outE.label.toSet should be(Set("knows", "knows", "created"))
-      graph.v(1).outE(1).label.toSet should be(Set("knows"))
+      val outLabels = Set("knows", "knows", "created")
+      graph.v(1).outE.label.toSet should be(outLabels)
+      val resultsLimited = graph.v(1).outE(1).label.toList
+      resultsLimited.size should be(1)
+      outLabels.intersect(resultsLimited.toSet).size should be(1)
 
       graph.v(1).outE("knows", "created").inV.name.toSet should be(Set("vadas", "josh", "lop"))
     }
@@ -80,11 +89,16 @@ class TraversalStepsTest extends FunSpec with ShouldMatchers with TestGraph {
     }
 
     it("follows in edges by label") {
-      graph.v(3).in("created").property("name").toSet should be(Set("marko", "josh", "peter"))
-      graph.v(3).in(1, "created").property("name").toSet should be(Set("marko"))
+      val inNames = Set("marko", "josh", "peter")
+      graph.v(3).in("created").property("name").toSet should be(inNames)
+      var resultsLimited1 = graph.v(3).in(1, "created").property("name").toList
+      resultsLimited1.size should be(1)
+      inNames.intersect(resultsLimited1.toSet).size should be(1)
 
-      graph.v(3).inE("created").outV.property("name").toSet should be(Set("marko", "josh", "peter"))
-      graph.v(3).inE(1, "created").outV.property("name").toSet should be(Set("marko"))
+      graph.v(3).inE("created").outV.property("name").toSet should be(inNames)
+      val resultsLimited2 = graph.v(3).inE(2, "created").outV.property("name").toList
+      resultsLimited2.size should be(2)
+      inNames.intersect(resultsLimited2.toSet).size should be(2)
     }
 
     it("traverses multiple steps") {


### PR DESCRIPTION
I was seeing some test failures due to assumed iteration order of the `out` and `in` methods. I added explicit ordering to the one test that needed it, and updated the other tests to assert on result size & values in a set, instead of for explicit values.

I think this is correct - there's no defined ordering for nodes, right?

lmk if you want more info to reproduce. I'm running:

```
$ java -version
java version "1.8.0_05"
Java(TM) SE Runtime Environment (build 1.8.0_05-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.5-b02, mixed mode)
```

on OS X 10.9.4.
