### PR TITLE
Fixed JSR232 log warning by removing reference in scripts folder

### DIFF
--- a/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,1 +1,0 @@
-com.tinkerpop.gremlin.scala.jsr223.ScriptEngineFactory


### PR DESCRIPTION
Fixed the warning that was displayed when the script engine couldn't find the JSR232 classes
