### PR TITLE
Compile time load and save, #73

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import sbt._
+import Keys._
+
 name := "gremlin-scala"
 organization := "com.michaelpollmeier"
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
@@ -6,6 +9,8 @@ homepage := Some(url("https://github.com/mpollmeier/gremlin-scala"))
 version := "3.0.0-SNAPSHOT"
 scalaVersion := "2.11.7"
 crossScalaVersions := Seq("2.10.5", scalaVersion.value)
+
+
 
 libraryDependencies <++= scalaVersion { scalaVersion =>
   val gremlinVersion = "3.0.0-incubating"
@@ -20,6 +25,11 @@ libraryDependencies <++= scalaVersion { scalaVersion =>
     "org.scalatest" %% "scalatest" % "2.2.5" % Test
   )
 }
+libraryDependencies ++= (
+
+  if (scalaVersion.value.startsWith("2.10")) List(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full))
+  else Nil
+  )
 resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/"
 resolvers += Resolver.mavenLocal
 

--- a/src/main/scala/gremlin/scala/SafeMapper.scala
+++ b/src/main/scala/gremlin/scala/SafeMapper.scala
@@ -1,0 +1,96 @@
+package gremlin.scala
+
+/**
+ * Created by Omid on 7/26/2015.
+ */
+
+
+import shapeless._, labelled.{ FieldType, field },record._
+
+trait FromMap[L <: HList] {
+  def apply(m: Map[String, Any]): Option[L]
+}
+
+trait ToMapRec[L <: HList] { def apply(l: L): Map[String, Any] }
+
+trait LowPriorityToMapRec {
+  implicit def hconsToMapRec1[K <: Symbol, V, T <: HList](implicit
+                                                          wit: Witness.Aux[K],
+                                                          tmrT: ToMapRec[T]
+                                                           ): ToMapRec[FieldType[K, V] :: T] = new ToMapRec[FieldType[K, V] :: T] {
+    def apply(l: FieldType[K, V] :: T): Map[String, Any] =
+      tmrT(l.tail) + (wit.value.name -> l.head)
+  }
+}
+
+trait LowPriorityFromMap {
+  implicit def hconsFromMap1[K <: Symbol, V, T <: HList](implicit
+                                                         witness: Witness.Aux[K],
+                                                         typeable: Typeable[V],
+                                                         fromMapT: FromMap[T]
+                                                          ): FromMap[FieldType[K, V] :: T] = new FromMap[FieldType[K, V] :: T] {
+    def apply(m: Map[String, Any]): Option[FieldType[K, V] :: T] = for {
+      v <- m.get(witness.value.name)
+      h <- typeable.cast(v)
+      t <- fromMapT(m)
+    } yield field[K](h) :: t
+  }
+}
+
+object ToMapRec extends LowPriorityToMapRec {
+  implicit val hnilToMapRec: ToMapRec[HNil] = new ToMapRec[HNil] {
+    def apply(l: HNil): Map[String, Any] = Map.empty
+  }
+
+  implicit def hconsToMapRec0[K <: Symbol, V, R <: HList, T <: HList](implicit
+                                                                      wit: Witness.Aux[K],
+                                                                      gen: LabelledGeneric.Aux[V, R],
+                                                                      tmrH: ToMapRec[R],
+                                                                      tmrT: ToMapRec[T]
+                                                                       ): ToMapRec[FieldType[K, V] :: T] = new ToMapRec[FieldType[K, V] :: T] {
+    def apply(l: FieldType[K, V] :: T): Map[String, Any] =
+      tmrT(l.tail) + (wit.value.name -> tmrH(gen.to(l.head)))
+  }
+}
+
+object FromMap extends LowPriorityFromMap {
+  implicit val hnilFromMap: FromMap[HNil] = new FromMap[HNil] {
+    def apply(m: Map[String, Any]): Option[HNil] = Some(HNil)
+  }
+
+  implicit def hconsFromMap0[K <: Symbol, V, R <: HList, T <: HList](implicit
+                                                                     witness: Witness.Aux[K],
+                                                                     gen: LabelledGeneric.Aux[V, R],
+                                                                     fromMapH: FromMap[R],
+                                                                     fromMapT: FromMap[T]
+                                                                      ): FromMap[FieldType[K, V] :: T] = new FromMap[FieldType[K, V] :: T] {
+    def apply(m: Map[String, Any]): Option[FieldType[K, V] :: T] = for {
+      v <- m.get(witness.value.name)
+      r <- Typeable[Map[String, Any]].cast(v)
+      h <- fromMapH(r)
+      t <- fromMapT(m)
+    } yield field[K](gen.from(h)) :: t
+  }
+}
+
+trait CcFromMapRec[A] { def apply(a: Map[String, Any]): Option[A] }
+
+object CcFromMapRec {
+  implicit def ccFromMapRec[A, R <: HList](implicit
+                                         gen: LabelledGeneric.Aux[A, R],
+                                           fromMap: FromMap[R]
+                                          ): CcFromMapRec[A] = new CcFromMapRec[A] {
+    def apply(a: Map[String, Any]): Option[A] = fromMap(a).map(gen.from(_))
+  }
+}
+
+trait CcToMapRec[A] { def apply(a: A): Map[String, Any] }
+
+object CcToMapRec {
+  implicit def ccToMapRec[A, R <: HList](implicit
+                                         gen: LabelledGeneric.Aux[A, R],
+                                         tmr: ToMapRec[R]
+                                          ): CcToMapRec[A] = new CcToMapRec[A] {
+    def apply(a: A): Map[String, Any] = tmr(gen.to(a))
+  }
+}

--- a/src/main/scala/gremlin/scala/ScalaGraph.scala
+++ b/src/main/scala/gremlin/scala/ScalaGraph.scala
@@ -2,6 +2,7 @@ package gremlin.scala
 
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import shapeless._
+import shapeless.labelled.FieldType
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 import scala.collection.JavaConverters._
@@ -41,39 +42,8 @@ case class ScalaGraph(graph: Graph) {
   def E(edgeIds: AnyRef*) = GremlinScala[Edge, HNil](graph.traversal.E(edgeIds: _*).asInstanceOf[GraphTraversal[_, Edge]])
 
   // save an object's values into a new vertex
-  def save[A: TypeTag: ClassTag](cc: A): ScalaVertex = {
-    val persistableTypes = Seq(
-      typeOf[Option.type],
-      typeOf[String],
-      typeOf[Int],
-      typeOf[Double],
-      typeOf[Float],
-      typeOf[Long],
-      typeOf[Short],
-      typeOf[Char],
-      typeOf[Byte],
-      typeOf[Seq.type],
-      typeOf[Map.type]
-    ) map (_.typeSymbol.fullName)
-
-    val mirror = runtimeMirror(getClass.getClassLoader)
-    val instanceMirror = mirror.reflect(cc)
-
-    // TODO: when we don't need to support scala 2.10 any more, change to: typeOf[A].declarations
-    val params = (typeOf[A].declarations map (_.asTerm) filter (t ⇒ t.isParamAccessor && t.isGetter) map { term ⇒
-      val termName = term.name.decodedName.toString
-      val termType = term.typeSignature.typeSymbol.fullName
-      if (!persistableTypes.contains(termType))
-        throw new IllegalArgumentException(s"The field '$termName: $termType' is not persistable.")
-
-      val fieldMirror = instanceMirror.reflectField(term)
-      termName → (term.typeSignature.typeSymbol.fullName match {
-        case t if t == typeOf[Option.type].typeSymbol.fullName ⇒
-          fieldMirror.get.asInstanceOf[Option[Any]].orNull
-        case _ ⇒ fieldMirror.get
-      })
-    } filter { case (key, value) ⇒ key != "id" && value != null }).toMap + ("label" → cc.getClass.getSimpleName)
-
+  def save[A](cc: A)(implicit ctmr: CcToMapRec[A]): ScalaVertex = {
+    val params = ctmr(cc)
     addVertex().setProperties(params)
   }
 }

--- a/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -53,4 +53,9 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   }
 
   def start() = GremlinScala[Vertex, HNil](__.__(vertex))
+
+  def load[A](implicit fm:CcFromMapRec[A]):Option[A] = {
+    val mp = vertex.valueMap()
+    fm(mp)
+  }
 }

--- a/src/test/scala/gremlin/scala/MarshallerSpec.scala
+++ b/src/test/scala/gremlin/scala/MarshallerSpec.scala
@@ -6,6 +6,9 @@ import org.scalatest.Matchers
 
 case class ExampleClass(s: String, i: Int, l: Long, o: Option[String], seq: Seq[String], map: Map[String, String])
 
+case class Person(name:String, age:Int, address:Address)
+case class Address(zip:Int, street:String)
+
 class MarshallerSpec extends FunSpec with Matchers {
   val example = ExampleClass(
     "some string",
@@ -16,6 +19,8 @@ class MarshallerSpec extends FunSpec with Matchers {
     Map("key1" -> "value1", "key2" -> "value2")
   )
 
+  val jack = Person("Jack", 20, Address(11111, "Jefferson"))
+
   it("saves a case class as a vertex") {
     val graph = TinkerGraph.open
     val gs = GremlinScala(graph)
@@ -25,7 +30,7 @@ class MarshallerSpec extends FunSpec with Matchers {
     v.valueMap should contain ("s" → example.s)
     v.valueMap should contain ("i" → example.i)
     v.valueMap should contain ("l" → example.l)
-    v.valueMap should contain ("o" → example.o.get)
+    v.valueMap should contain ("o" → example.o)
     v.valueMap should contain ("seq" → example.seq)
     v.valueMap should contain ("map" → example.map)
 
@@ -37,7 +42,27 @@ class MarshallerSpec extends FunSpec with Matchers {
     val gs = GremlinScala(graph)
 
     val v = gs.save(example)
+    val v2 = v.load[ExampleClass]
+    example shouldBe v2.get
+  }
 
-    v.start.load[ExampleClass].head shouldBe example
+  it("saves a nested case class"){
+    val graph = TinkerGraph.open
+    val gs = GremlinScala(graph)
+
+    val v = gs.save(jack)
+    v.valueMap should contain ("name" → jack.name)
+    v.valueMap should contain ("age" → jack.age)
+    v.valueMap should contain ("address" → Map("street" -> "Jefferson", "zip" ->11111))
+  }
+
+  it("load nested case class"){
+    val graph = TinkerGraph.open
+    val gs = GremlinScala(graph)
+
+    val v = gs.save(jack)
+
+    v.load[Person].get shouldBe jack
+
   }
 }


### PR DESCRIPTION
After talking about compile time save/load from #73 , I added `load` and `save` that uses shapeless in compile time to do the conversion and it's fully typed safe. It also works with nested case classes like:

```scala
case class Person(name:String, age:Int, address:Address)
case class Address(zip:Int, street:String)
val jack = Person("Jack", 20, Address(11111, "Jefferson"))
```
it's very simple at user end:
```scala
val v = gs.save(jack)
val jackV = v.load[Person]
```
I deleted the existing reflection based code for `save` but I left the method `load` in package object. We can also delete that because I already added `load` in `ScalaVertex`. 
`load` also returns `Option` so it's safe if someone cast it wrong. Two new test cases also has been added for nested case classes. I also should thank @travisbrown for his helps.