### PR TITLE
SemiEdge enhancement

### DIFF
--- a/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -7,7 +7,7 @@ import shapeless._
 case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   override def element = vertex
 
-  def --(label: String) = SemiEdge(vertex, label)
+  def --(label: String, properties: (String, Any)*) = SemiEdge(vertex, label, properties.toMap)
 
   def setProperty(key: String, value: Any): ScalaVertex = {
     element.property(key, value)

--- a/src/main/scala/gremlin/scala/SemiEdge.scala
+++ b/src/main/scala/gremlin/scala/SemiEdge.scala
@@ -1,5 +1,5 @@
 package gremlin.scala
 
-case class SemiEdge(from: Vertex, label: String) {
-  def ->(to: Vertex) = from.addEdge(label, to)
+case class SemiEdge(from: Vertex, label: String, properties: Map[String, Any]) {
+  def ->(to: Vertex) = from.addEdge(label, to).setProperties(properties)
 }

--- a/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
+++ b/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
@@ -17,4 +17,18 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
     e.inVertex shouldBe london
     e.outVertex shouldBe paris
   }
+
+  it("add edge with properties using syntax sugar") {
+    val graph: Graph = TinkerGraph.open
+
+    val paris = graph.addVertex("Paris")
+    val london = graph.addVertex("London")
+
+    val e = paris -- ("eurostar", "type" -> "WDiEdge", "weight" -> 2) -> london
+
+    e.inVertex shouldBe london
+    e.outVertex shouldBe paris
+    e.value("type") shouldBe Some("WDiEdge")
+    e.value("weight") shouldBe Some(2)
+  }
 }


### PR DESCRIPTION
Added support for passing varargs of pairs to set the properties of the Edge after adding it.  
Should this syntax be altered to be compatible with blueprints-scala (recognizably obsolete) which is different as shown.  I would love to expand this and be more involved in this project.
```
hercules --> "father" --> jupiter
jupiter <--> "brother" <--> neptune
```