### PR TITLE
use java types by default

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaEdge.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaEdge.scala
@@ -6,31 +6,31 @@ import scala.collection.JavaConversions._
 case class ScalaEdge(edge: Edge) extends ScalaElement[Edge] {
   override def element = edge
 
-  override def setProperty(key: String, value: Any): ScalaEdge = {
+  override def setProperty(key: String, value: Any): Edge = {
     element.property(key, value)
-    this
+    edge
   }
 
-  def setProperties(properties: Map[String, Any]): ScalaEdge = {
+  def setProperties(properties: Map[String, Any]): Edge = {
     properties foreach { case (k, v) ⇒ setProperty(k, v) }
-    this
+    edge
   }
 
-  def setProperties[T <: Product: Marshallable](cc: T): ScalaEdge = {
+  def setProperties[T <: Product: Marshallable](cc: T): Edge = {
     val (_, _, properties) = implicitly[Marshallable[T]].fromCC(cc)
     setProperties(properties)
-    this
+    edge
   }
 
-  override def removeProperty(key: String): ScalaEdge = {
+  override def removeProperty(key: String): Edge = {
     val p = property(key)
     if (p.isPresent) p.remove()
-    this
+    edge
   }
 
-  override def removeProperties(keys: String*): ScalaEdge = {
+  override def removeProperties(keys: String*): Edge = {
     keys foreach removeProperty
-    this
+    edge
   }
 
   def toCC[T <: Product: Marshallable] =

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
@@ -16,11 +16,11 @@ trait ScalaElement[ElementType <: Element] {
 
   def keys: Set[String] = element.keys.toSet
 
-  def setProperty(key: String, value: Any): ScalaElement[ElementType]
+  def setProperty(key: String, value: Any): ElementType
 
-  def removeProperty(key: String): ScalaElement[ElementType]
+  def removeProperty(key: String): ElementType
 
-  def removeProperties(keys: String*): ScalaElement[ElementType]
+  def removeProperties(keys: String*): ElementType
 
   def property[A: DefaultsToAny](key: String): Property[A] = element.property[A](key)
 

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaGraph.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaGraph.scala
@@ -10,32 +10,32 @@ import scala.collection.JavaConversions._
 
 case class ScalaGraph[G <: Graph](graph: G) {
 
-  def addVertex(label: String): ScalaVertex = graph.addVertex(label)
+  def addVertex(label: String): Vertex = graph.addVertex(label)
 
-  def addVertex(): ScalaVertex = graph.addVertex()
+  def addVertex(): Vertex = graph.addVertex()
 
-  def addVertex(label: String, properties: (String, Any)*): ScalaVertex = {
+  def addVertex(label: String, properties: (String, Any)*): Vertex = {
     val labelParam = Seq(T.label, label)
     val params = properties.flatMap(pair ⇒ Seq(pair._1, pair._2.asInstanceOf[AnyRef]))
     graph.addVertex(labelParam ++ params: _*)
   }
 
-  def addVertex(properties: (String, Any)*): ScalaVertex = {
+  def addVertex(properties: (String, Any)*): Vertex = {
     val params = properties.flatMap(pair ⇒ Seq(pair._1, pair._2.asInstanceOf[AnyRef]))
     graph.addVertex(params: _*)
   }
 
-  def addVertex(label: String, properties: Map[String, Any]): ScalaVertex =
+  def addVertex(label: String, properties: Map[String, Any]): Vertex =
     addVertex(label, properties.toSeq: _*)
 
-  def addVertex(properties: Map[String, Any]): ScalaVertex =
+  def addVertex(properties: Map[String, Any]): Vertex =
     addVertex(properties.toSeq: _*)
 
   /**
     * Save an object's values into a new vertex
     * @param cc The case class to persist as a vertex
     */
-  def addVertex[P <: Product: Marshallable](cc: P): ScalaVertex = {
+  def addVertex[P <: Product: Marshallable](cc: P): Vertex = {
     val (id, label, properties) = implicitly[Marshallable[P]].fromCC(cc)
     val idParam = id.toSeq flatMap (List(T.id, _))
     val labelParam = Seq(T.label, label)
@@ -43,17 +43,17 @@ case class ScalaGraph[G <: Graph](graph: G) {
     graph.addVertex(idParam ++ labelParam ++ params: _*)
   }
 
-  def +(label: String): ScalaVertex = addVertex(label)
+  def +(label: String): Vertex = addVertex(label)
 
-  def +(label: String, properties: (String, Any)*): ScalaVertex = addVertex(label, properties.toMap)
+  def +(label: String, properties: (String, Any)*): Vertex = addVertex(label, properties.toMap)
 
   // get vertex by id
-  def v(id: Any): Option[ScalaVertex] =
-    graph.traversal.V(id.asInstanceOf[AnyRef]).headOption map ScalaVertex.apply
+  def v(id: Any): Option[Vertex] =
+    graph.traversal.V(id.asInstanceOf[AnyRef]).headOption
 
   // get edge by id
-  def e(id: Any): Option[ScalaEdge] =
-    graph.traversal.E(id.asInstanceOf[AnyRef]).headOption map ScalaEdge.apply
+  def e(id: Any): Option[Edge] =
+    graph.traversal.E(id.asInstanceOf[AnyRef]).headOption
 
   // start traversal with all vertices 
   def V = GremlinScala[Vertex, HNil](graph.traversal.V().asInstanceOf[GraphTraversal[_, Vertex]])
@@ -71,11 +71,11 @@ case class ScalaGraph[G <: Graph](graph: G) {
     GremlinScala[Edge, HNil](graph.traversal.E(edgeIds.asInstanceOf[Seq[AnyRef]]: _*)
     .asInstanceOf[GraphTraversal[_, Edge]])
 
-  def edges(edgeIds: Any*): Iterator[ScalaEdge] =
-    graph.edges(edgeIds.asInstanceOf[Seq[AnyRef]]) map (_.asScala)
+  def edges(edgeIds: Any*): Iterator[Edge] =
+    graph.edges(edgeIds.asInstanceOf[Seq[AnyRef]])
 
-  def vertices(vertexIds: Any*): Iterator[ScalaVertex] =
-    graph.vertices(vertexIds.asInstanceOf[Seq[AnyRef]]) map (_.asScala)
+  def vertices(vertexIds: Any*): Iterator[Vertex] =
+    graph.vertices(vertexIds.asInstanceOf[Seq[AnyRef]])
 
   def tx(): Transaction = graph.tx()
 

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -13,25 +13,25 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   def toCC[P <: Product : Marshallable] =
     implicitly[Marshallable[P]].toCC(vertex.id, vertex.valueMap)
 
-  override def setProperty(key: String, value: Any): ScalaVertex = {
+  override def setProperty(key: String, value: Any): Vertex = {
     element.property(key, value)
-    this
+    vertex
   }
 
-  def setProperties(properties: Map[String, Any]): ScalaVertex = {
+  def setProperties(properties: Map[String, Any]): Vertex = {
     properties foreach { case (k, v) ⇒ setProperty(k, v) }
-    this
+    vertex
   }
 
-  override def removeProperty(key: String): ScalaVertex = {
+  override def removeProperty(key: String): Vertex = {
     val p = property(key)
     if (p.isPresent) p.remove()
-    this
+    vertex
   }
 
-  override def removeProperties(keys: String*): ScalaVertex = {
+  override def removeProperties(keys: String*): Vertex = {
     keys foreach removeProperty
-    this
+    vertex
   }
 
   def out() = start().out()
@@ -59,31 +59,31 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   def bothE(labels: String*) = start().bothE(labels: _*)
 
   def addEdge(label: String,
-              inVertex: ScalaVertex,
-              properties: Map[String, Any] = Map.empty): ScalaEdge = {
+              inVertex: Vertex,
+              properties: Map[String, Any] = Map.empty): Edge = {
     val params = properties.toSeq.flatMap(pair ⇒ Seq(pair._1, pair._2.asInstanceOf[AnyRef]))
     vertex.addEdge(label, inVertex.vertex, params: _*)
   }
 
-  def addEdge[P <: Product : Marshallable](inVertex: ScalaVertex, cc: P): ScalaEdge = {
+  def addEdge[P <: Product : Marshallable](inVertex: Vertex, cc: P): ScalaEdge = {
     val (id, label, properties) = implicitly[Marshallable[P]].fromCC(cc)
     val idParam = id.toSeq flatMap (List(T.id, _))
     val params = properties.toSeq.flatMap(pair ⇒ Seq(pair._1, pair._2.asInstanceOf[AnyRef]))
     vertex.addEdge(label, inVertex.vertex, idParam ++ params: _*)
   }
 
-  def <--(se: SemiEdge) = se.from.addEdge(se.label, this, se.properties)
+  def <--(se: SemiEdge) = se.from.addEdge(se.label, vertex, se.properties)
 
-  def <--(de: SemiDoubleEdge): (ScalaEdge, ScalaEdge) =
-    addEdge(de.label, de.right, de.properties) → de.right.addEdge(de.label, this, de.properties)
+  def <--(de: SemiDoubleEdge): (Edge, Edge) =
+    addEdge(de.label, de.right, de.properties) → de.right.addEdge(de.label, vertex, de.properties)
 
-  def ---(label: String) = SemiEdge(this, label)
+  def ---(label: String) = SemiEdge(vertex, label)
 
-  def ---(label: String, properties: (String, Any)*) = SemiEdge(this, label, properties.toMap)
+  def ---(label: String, properties: (String, Any)*) = SemiEdge(vertex, label, properties.toMap)
 
   def ---[P <: Product : Marshallable](cc: P) = {
     val (_, label, properties) = implicitly[Marshallable[P]].fromCC(cc)
-    SemiEdge(this, label, properties)
+    SemiEdge(vertex, label, properties)
   }
 
   override def start() = GremlinScala[Vertex, HNil](__(vertex))

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -72,10 +72,10 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
     vertex.addEdge(label, inVertex.vertex, idParam ++ params: _*)
   }
 
-  def <--(se: SemiEdge) = se.from.addEdge(se.label, vertex, se.properties)
+  def <--(se: SemiEdge) = se.from.asScala.addEdge(se.label, vertex, se.properties)
 
   def <--(de: SemiDoubleEdge): (Edge, Edge) =
-    addEdge(de.label, de.right, de.properties) → de.right.addEdge(de.label, vertex, de.properties)
+    addEdge(de.label, de.right, de.properties) → de.right.asScala.addEdge(de.label, vertex, de.properties)
 
   def ---(label: String) = SemiEdge(vertex, label)
 

--- a/gremlin-scala/src/main/scala/gremlin/scala/SemiEdge.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/SemiEdge.scala
@@ -1,8 +1,7 @@
 package gremlin.scala
 
 case class SemiEdge(from: Vertex, label: String, properties: Map[String, Any] = Map.empty) {
-
-  def -->(to: Vertex) = from.addEdge(label, to, properties)
+  def -->(to: Vertex) = from.asScala.addEdge(label, to, properties)
 }
 
 case class SemiDoubleEdge(right: Vertex, label: String, properties: Map[String, Any] = Map.empty)

--- a/gremlin-scala/src/main/scala/gremlin/scala/SemiEdge.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/SemiEdge.scala
@@ -1,8 +1,8 @@
 package gremlin.scala
 
-case class SemiEdge(from: ScalaVertex, label: String, properties: Map[String, Any] = Map.empty) {
+case class SemiEdge(from: Vertex, label: String, properties: Map[String, Any] = Map.empty) {
 
-  def -->(to: ScalaVertex) = from.addEdge(label, to, properties)
+  def -->(to: Vertex) = from.addEdge(label, to, properties)
 }
 
-case class SemiDoubleEdge(right: ScalaVertex, label: String, properties: Map[String, Any] = Map.empty)
+case class SemiDoubleEdge(right: Vertex, label: String, properties: Map[String, Any] = Map.empty)

--- a/gremlin-scala/src/main/scala/gremlin/scala/package.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/package.scala
@@ -112,9 +112,9 @@ package object scala {
 
   // Arrow syntax implicits
   implicit class SemiEdgeFunctions(label: String) {
-    def ---(from: ScalaVertex) = SemiEdge(from, label)
+    def ---(from: Vertex) = SemiEdge(from, label)
 
-    def -->(right: ScalaVertex) = SemiDoubleEdge(right, label)
+    def -->(right: Vertex) = SemiDoubleEdge(right, label)
   }
 
   implicit class SemiEdgeProductFunctions[A <: Product](t: (String, A))(implicit tag: TypeTag[A]) {
@@ -128,16 +128,16 @@ package object scala {
         }
       }
 
-    def ---(from: ScalaVertex) = SemiEdge(from, label, properties)
+    def ---(from: Vertex) = SemiEdge(from, label, properties)
   }
 
   implicit class SemiEdgeCcFunctions[T <: Product: Marshallable](cc: T) {
-    def ---(from: ScalaVertex) = {
+    def ---(from: Vertex) = {
       val (_, label, properties) = implicitly[Marshallable[T]].fromCC(cc)
       SemiEdge(from, label, properties)
     }
 
-    def -->(from: ScalaVertex) = {
+    def -->(from: Vertex) = {
       val (_, label, properties) = implicitly[Marshallable[T]].fromCC(cc)
       SemiDoubleEdge(from, label, properties)
     }

--- a/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
@@ -13,8 +13,8 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
 
     val e = paris --- "eurostar" --> london
 
-    e.asJava.inVertex shouldBe london.asJava
-    e.asJava.outVertex shouldBe paris.asJava
+    e.inVertex shouldBe london
+    e.outVertex shouldBe paris
   }
 
   it("add edge with case class") {
@@ -33,8 +33,8 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
       NestedClass("nested")
     ) --> london
 
-    e.asJava.inVertex shouldBe london.asJava
-    e.asJava.outVertex shouldBe paris.asJava
+    e.inVertex shouldBe london
+    e.outVertex shouldBe paris
   }
 
   it("add bidirectional edge with case class") {
@@ -52,11 +52,11 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
       NestedClass("nested")
     ) --> london
 
-    e0.asJava.inVertex shouldBe london.asJava
-    e0.asJava.outVertex shouldBe paris.asJava
+    e0.inVertex shouldBe london
+    e0.outVertex shouldBe paris
 
-    e1.asJava.inVertex shouldBe paris.asJava
-    e1.asJava.outVertex shouldBe london.asJava
+    e1.inVertex shouldBe paris
+    e1.outVertex shouldBe london
   }
 
   it("add left edge with case class") {
@@ -75,8 +75,8 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
       NestedClass("nested")
     ) --- london
 
-    e.asJava.inVertex shouldBe paris.asJava
-    e.asJava.outVertex shouldBe london.asJava
+    e.inVertex shouldBe paris
+    e.outVertex shouldBe london
   }
 
   it("add bidirectional edge with syntax sugar") {
@@ -87,11 +87,11 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
 
     val (edgeParisToLondon, edgeLondonToParis) = paris <-- "eurostar" --> london
 
-    edgeParisToLondon.asJava.inVertex shouldBe london.asJava
-    edgeParisToLondon.asJava.outVertex shouldBe paris.asJava
+    edgeParisToLondon.inVertex shouldBe london
+    edgeParisToLondon.outVertex shouldBe paris
 
-    edgeLondonToParis.asJava.inVertex shouldBe paris.asJava
-    edgeLondonToParis.asJava.outVertex shouldBe london.asJava
+    edgeLondonToParis.inVertex shouldBe paris
+    edgeLondonToParis.outVertex shouldBe london
   }
 
   it("add edge with properties using syntax sugar") {
@@ -102,10 +102,10 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
 
     val e = paris --- ("eurostar", "type" → "WDiEdge", "weight" → 2) --> london
 
-    e.asJava.inVertex shouldBe london.asJava
-    e.asJava.outVertex shouldBe paris.asJava
-    e.value("type") shouldBe Some("WDiEdge")
-    e.value("weight") shouldBe Some(2)
+    e.inVertex shouldBe london
+    e.outVertex shouldBe paris
+    e.value[String]("type") shouldBe Some("WDiEdge")
+    e.value[Int]("weight") shouldBe Some(2)
   }
 
   it("add left edge with properties using syntax sugar") {
@@ -116,8 +116,8 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
 
     val e = paris <-- ("eurostar", "type" → "WDiEdge") --- london
 
-    e.asJava.inVertex shouldBe paris.asJava
-    e.asJava.outVertex shouldBe london.asJava
-    e.value("type") shouldBe Some("WDiEdge")
+    e.inVertex shouldBe paris
+    e.outVertex shouldBe london
+    e.value[String]("type") shouldBe Some("WDiEdge")
   }
 }

--- a/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
@@ -104,8 +104,8 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
 
     e.inVertex shouldBe london
     e.outVertex shouldBe paris
-    e.value[String]("type") shouldBe Some("WDiEdge")
-    e.value[Int]("weight") shouldBe Some(2)
+    e.value[String]("type") shouldBe "WDiEdge"
+    e.value[Int]("weight") shouldBe 2
   }
 
   it("add left edge with properties using syntax sugar") {
@@ -118,6 +118,6 @@ class ArrowSyntaxSpec extends FunSpec with Matchers {
 
     e.inVertex shouldBe paris
     e.outVertex shouldBe london
-    e.value[String]("type") shouldBe Some("WDiEdge")
+    e.value[String]("type") shouldBe "WDiEdge"
   }
 }

--- a/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
@@ -13,8 +13,8 @@ class ElementSpec extends TestBase {
       v(1).property[String]("doesnt exit").isPresent shouldBe false
       v(1).valueMap shouldBe Map("name" -> "marko", "age" -> 29)
       v(1).valueMap("name", "age") shouldBe Map("name" -> "marko", "age" -> 29)
-      v(1).properties("name", "age").length shouldBe 2
-      v(1).properties.length shouldBe 2
+      v(1).asScala.properties("name", "age") shouldBe 2
+      v(1).asScala.properties.length shouldBe 2
 
       e(7).keys shouldBe Set("weight")
       e(7).property[Float]("weight").value shouldBe 0.5

--- a/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
@@ -8,77 +8,77 @@ class ElementSpec extends TestBase {
 
   describe("properties") {
     it("gets properties") {
-      v(1).keys shouldBe Set("name", "age")
-      v(1).property[String]("name").value should be("marko")
-      v(1).property[String]("doesnt exit").isPresent shouldBe false
-      v(1).valueMap shouldBe Map("name" -> "marko", "age" -> 29)
-      v(1).valueMap("name", "age") shouldBe Map("name" -> "marko", "age" -> 29)
-      v(1).asScala.properties("name", "age") shouldBe 2
-      v(1).asScala.properties.length shouldBe 2
+      v1.keys shouldBe Set("name", "age")
+      v1.property[String]("name").value should be("marko")
+      v1.property[String]("doesnt exit").isPresent shouldBe false
+      v1.valueMap shouldBe Map("name" → "marko", "age" → 29)
+      v1.valueMap("name", "age") shouldBe Map("name" → "marko", "age" → 29)
+      v1.properties("name", "age").length shouldBe 2
+      v1.properties.length shouldBe 2
 
-      e(7).keys shouldBe Set("weight")
-      e(7).property[Float]("weight").value shouldBe 0.5
-      e(7).property[Float]("doesnt exit").isPresent shouldBe false
-      e(7).valueMap("weight") shouldBe Map("weight" -> 0.5)
+      e7.keys shouldBe Set("weight")
+      e7.property[Float]("weight").value shouldBe 0.5
+      e7.property[Float]("doesnt exit").isPresent shouldBe false
+      e7.valueMap("weight") shouldBe Map("weight" → 0.5)
     }
 
     it("sets a property") {
-      v(1).setProperty("vertexProperty", "updated")
-      v(1).property[String]("vertexProperty").value shouldBe "updated"
+      v1.setProperty("vertexProperty", "updated")
+      v1.property[String]("vertexProperty").value shouldBe "updated"
 
-      e(7).setProperty("edgeProperty", "updated")
-      e(7).property[String]("edgeProperty").value shouldBe "updated"
+      e7.setProperty("edgeProperty", "updated")
+      e7.property[String]("edgeProperty").value shouldBe "updated"
     }
 
     it("removes a property") {
-      v(1).setProperty("vertexProperty1", "updated")
-      v(1).removeProperty("vertexProperty1")
-      v(1).removeProperty("doesnt exist")
-      v(1).property[String]("vertexProperty1").isPresent shouldBe false
+      v1.setProperty("vertexProperty1", "updated")
+      v1.removeProperty("vertexProperty1")
+      v1.removeProperty("doesnt exist")
+      v1.property[String]("vertexProperty1").isPresent shouldBe false
 
-      e(7).setProperty("edgeProperty", "updated")
-      e(7).removeProperty("edgeProperty")
-      e(7).removeProperty("doesnt exist")
-      e(7).property[String]("edgeProperty").isPresent shouldBe false
+      e7.setProperty("edgeProperty", "updated")
+      e7.removeProperty("edgeProperty")
+      e7.removeProperty("doesnt exist")
+      e7.property[String]("edgeProperty").isPresent shouldBe false
     }
   }
 
   describe("values") {
     it("gets a value") {
-      v(1).value[String]("name") shouldBe Some("marko")
-      v(1).value[String]("doesn't exist") shouldBe None
-      v(1).getValue[String]("name") shouldBe "marko"
-      e(7).value[Float]("weight") shouldBe Some(0.5)
+      v1.value[String]("name") shouldBe Some("marko")
+      v1.value[String]("doesn't exist") shouldBe None
+      v1.getValue[String]("name") shouldBe "marko"
+      e7.value[Float]("weight") shouldBe Some(0.5)
     }
 
     it("falls back to default value if value doesnt exist") {
-      v(1).valueOrElse("doesnt exist", "blub") shouldBe "blub"
-      e(7).valueOrElse("doesnt exist", 0.8) shouldBe 0.8
+      v1.valueOrElse("doesnt exist", "blub") shouldBe "blub"
+      e7.valueOrElse("doesnt exist", 0.8) shouldBe 0.8
     }
 
     it("returns None if it doesn't exist") {
-      v(1).value[String]("doesnt exit") shouldBe None
-      e(7).value[Float]("doesnt exit") shouldBe None
+      v1.value[String]("doesnt exit") shouldBe None
+      e7.value[Float]("doesnt exit") shouldBe None
     }
   }
 
   describe("id, equality and hashCode") {
     it("has an id") {
-      v(1).id shouldBe 1
-      e(7).id shouldBe 7
+      v1.id shouldBe 1
+      e7.id shouldBe 7
     }
 
     it("equals") {
-      v(1) == v(1) shouldBe true
-      v(1) == v(2) shouldBe false
+      v1 == v(1).asScala shouldBe true
+      v1 == v(2).asScala shouldBe false
     }
 
     it("uses the right hashCodes") {
-      v(1).hashCode shouldBe v(1).hashCode
-      v(1).hashCode should not be v(2).hashCode
+      v1.hashCode shouldBe v(1).asScala.hashCode
+      v1.hashCode should not be v(2).asScala.hashCode
 
-      Set(v(1)) contains v(1) shouldBe true
-      Set(v(1)) contains v(2) shouldBe false
+      Set(v1) contains v(1) shouldBe true
+      Set(v1) contains v(2) shouldBe false
     }
   }
 
@@ -113,27 +113,11 @@ class ElementSpec extends TestBase {
       val label2 = "label2"
 
       val v1 = graph + label1
-      val v2 = graph + (label2, "testkey" -> "testValue")
+      val v2 = graph + (label2, "testkey" → "testValue")
 
       graph.V.hasLabel(label1).head() shouldBe v1.vertex
       graph.V.hasLabel(label2).head() shouldBe v2.vertex
       graph.V.hasLabel(label2).head().value[String]("testkey") shouldBe "testValue"
-
-      graph.asJava.close()
-    }
-
-    it("adds a vertex and edges with a given label with syntactic sugar") {
-      val g = TinkerGraph.open.asScala
-      val label1 = "label1"
-      val label2 = "label2"
-      val testLabel = "testLabel"
-      (g + label1) --- testLabel --> (g + (label2, "testkey" -> "testValue"))
-
-      g.V.hasLabel(label1).head().label() shouldBe label1
-      g.V.hasLabel(label2).head().label() shouldBe label2
-      g.V.hasLabel(label2).head().value[String]("testkey") shouldBe "testValue"
-      g.V.hasLabel(label1).head().outE().head().label() shouldBe testLabel
-      g.V.hasLabel(label1).head().out(testLabel).head().label() shouldBe label2
 
       graph.asJava.close()
     }
@@ -154,9 +138,9 @@ class ElementSpec extends TestBase {
       val v1 = graph.addVertex()
       val v2 = graph.addVertex()
 
-      val e = v1.addEdge("testLabel", v2, Map("testKey" -> "testValue"))
+      val e = v1.asScala.addEdge("testLabel", v2, Map("testKey" → "testValue"))
       e.label shouldBe "testLabel"
-      e.valueMap("testKey") shouldBe Map("testKey" -> "testValue")
+      e.valueMap("testKey") shouldBe Map("testKey" → "testValue")
       v1.outE().head shouldBe e.edge
       v1.out("testLabel").head shouldBe v2.vertex
     }
@@ -168,5 +152,8 @@ class ElementSpec extends TestBase {
       graph.V.toList() shouldBe empty
     }
   }
+
+  def v1 = v(1).asScala
+  def e7 = e(7).asScala
 }
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/FilterSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/FilterSpec.scala
@@ -21,6 +21,7 @@ class FilterSpec extends TestBase {
 
     val g = TinkerGraph.open.asScala
     g + (label("software"), name("blueprints"), created(2010))
+
     g.V.has(name("blueprints")).head <-- "dependsOn" --- (g + (label("software"), name("gremlin"), created(2009)))
     g.V.has(name("gremlin")).head <-- "dependsOn" --- (g + (label("software"), name("gremlinScala")))
     g.V.has(name("gremlinScala")).head <-- "createdBy" --- (g + (label("person"), name("mpollmeier")))

--- a/gremlin-scala/src/test/scala/gremlin/scala/LabelledPathSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/LabelledPathSpec.scala
@@ -20,7 +20,7 @@ class LabelledPathSpec extends TestBase {
 
     it("supports multiple steps") {
       val path: List[Vertex :: Edge :: HNil] =
-        v(1).as("a").outE.as("b").labelledPath.toList
+        v(1).asScala.as("a").outE.as("b").labelledPath.toList
 
       path should be(List(
         v(1).vertex :: e(9).edge :: HNil,
@@ -53,7 +53,7 @@ class LabelledPathSpec extends TestBase {
 
     it("supports arbitrary classes") {
       val path: List[Vertex :: Vertex :: String :: HNil] =
-        v(1).as("a").out.as("b").values[String]("name").as("c").labelledPath.toList
+        v(1).asScala.as("a").out.as("b").values[String]("name").as("c").labelledPath.toList
 
       path should be(List(
         v(1).vertex :: v(3).vertex :: "lop" :: HNil,

--- a/gremlin-scala/src/test/scala/gremlin/scala/LogicalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/LogicalSpec.scala
@@ -5,7 +5,7 @@ class LogicalSpec extends TestBase {
   describe("and steps") {
 
     it("returns a vertex if both conditions are met") {
-      val x = v(1)
+      val x = v(1).asScala
 
       x.and(
         _.out().has("name", "lop"),
@@ -14,7 +14,7 @@ class LogicalSpec extends TestBase {
     }
 
     it("returns empty set if one of the conditions isn't met") {
-      val x = v(1)
+      val x = v(1).asScala
 
       x.and(
         _.out().has("name", "lop"),
@@ -27,7 +27,7 @@ class LogicalSpec extends TestBase {
   describe("or steps") {
 
     it("returns a vertex if at least one condition is met") {
-      val x = v(1)
+      val x = v(1).asScala
 
       x.or(
         _.out().has("name", "lop"),
@@ -36,7 +36,7 @@ class LogicalSpec extends TestBase {
     }
 
     it("returns empty set if none condition is met") {
-      val x = v(1)
+      val x = v(1).asScala
 
       x.or(
         _.out().has("name", "bar"), // unmet condition
@@ -49,7 +49,7 @@ class LogicalSpec extends TestBase {
   describe("combination") {
 
     it("returns a vertex given and and or conditions are met") {
-      val x = v(1)
+      val x = v(1).asScala
 
       x.or(
         _.and(
@@ -61,7 +61,7 @@ class LogicalSpec extends TestBase {
     }
 
     it("returns an empty set given and and or conditions aren't met") {
-      val x = v(1)
+      val x = v(1).asScala
 
       x.and(
         _.or(

--- a/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
@@ -70,11 +70,11 @@ class SchemaSpec extends FunSpec with Matchers {
 
       val (edgeParisToLondon, edgeLondonToParis) = paris <-- EuroStar --> london
 
-      edgeParisToLondon.asJava.inVertex shouldBe london.asJava
-      edgeParisToLondon.asJava.outVertex shouldBe paris.asJava
+      edgeParisToLondon.inVertex shouldBe london
+      edgeParisToLondon.outVertex shouldBe paris
 
-      edgeLondonToParis.asJava.inVertex shouldBe paris.asJava
-      edgeLondonToParis.asJava.outVertex shouldBe london.asJava
+      edgeLondonToParis.inVertex shouldBe paris
+      edgeLondonToParis.outVertex shouldBe london
     }
 
     it("add edge with properties using syntax sugar") {
@@ -85,10 +85,10 @@ class SchemaSpec extends FunSpec with Matchers {
 
       val e = paris --- (EuroStar, Type("WDiEdge"), Weight(2)) --> london
 
-      e.asJava.inVertex shouldBe london.asJava
-      e.asJava.outVertex shouldBe paris.asJava
-      e.value(Type.key) shouldBe Some("WDiEdge")
-      e.value(Weight.key) shouldBe Some(2)
+      e.inVertex shouldBe london
+      e.outVertex shouldBe paris
+      e.value[String](Type.key) shouldBe Some("WDiEdge")
+      e.value[String](Weight.key) shouldBe Some(2)
     }
 
     it("to add left edge using syntax sugar with just Label") {
@@ -99,10 +99,10 @@ class SchemaSpec extends FunSpec with Matchers {
 
       val e = paris <-- EuroStar --- london
 
-      e.asJava.inVertex shouldBe paris.asJava
-      e.asJava.outVertex shouldBe london.asJava
+      e.inVertex shouldBe paris
+      e.outVertex shouldBe london
 
-      g.asJava.close()
+      g.close()
     }
 
     it("to add left edge using syntax sugar with Label and Name") {
@@ -113,10 +113,10 @@ class SchemaSpec extends FunSpec with Matchers {
 
       val e = paris <-- (EuroStar, Name("test")) --- london
 
-      e.asJava.inVertex shouldBe paris.asJava
-      e.asJava.outVertex shouldBe london.asJava
+      e.inVertex shouldBe paris
+      e.outVertex shouldBe london
 
-      g.asJava.close()
+      g.close()
     }
 
     it("to add left edge using syntax sugar with Label, Weight and Name") {
@@ -127,8 +127,8 @@ class SchemaSpec extends FunSpec with Matchers {
 
       val e = paris <-- (EuroStar, (Weight(99), Name("test"))) --- london
 
-      e.asJava.inVertex shouldBe paris.asJava
-      e.asJava.outVertex shouldBe london.asJava
+      e.inVertex shouldBe paris
+      e.outVertex shouldBe london
 
       g.asJava.close()
     }

--- a/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
@@ -88,7 +88,7 @@ class SchemaSpec extends FunSpec with Matchers {
       e.inVertex shouldBe london
       e.outVertex shouldBe paris
       e.value[String](Type.key) shouldBe "WDiEdge"
-      e.value[Integer](Weight.key) shouldBe 2
+      e.value[Int](Weight.key) shouldBe 2
     }
 
     it("to add left edge using syntax sugar with just Label") {

--- a/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
@@ -87,8 +87,8 @@ class SchemaSpec extends FunSpec with Matchers {
 
       e.inVertex shouldBe london
       e.outVertex shouldBe paris
-      e.value[String](Type.key) shouldBe Some("WDiEdge")
-      e.value[String](Weight.key) shouldBe Some(2)
+      e.value[String](Type.key) shouldBe "WDiEdge"
+      e.value[Integer](Weight.key) shouldBe 2
     }
 
     it("to add left edge using syntax sugar with just Label") {


### PR DESCRIPTION
@joan38 @dkrieg I'm not sure about this one... 
The goal is to make it less intrusive, i.e. only convert to ScalaVertex/ScalaEdge if needed. Which means that in some situations we need an extra call to `asScala`. Please let me know your thoughts. 