### PR TITLE
Remove atom

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -316,7 +316,7 @@ class GremlinElementSteps[End <: Element, Labels <: HList](gremlinScala: Gremlin
     GremlinScala[A, Labels](traversal.values[A](key))
 
   def value[A](key: Key[A]) =
-    GremlinScala[A, Labels](traversal.values[A](key.key))
+    GremlinScala[A, Labels](traversal.values[A](key.value))
 
   def values[A](key: String*) =
     GremlinScala[A, Labels](traversal.values[A](key: _*))
@@ -324,13 +324,13 @@ class GremlinElementSteps[End <: Element, Labels <: HList](gremlinScala: Gremlin
   def valueMap(keys: String*) =
     GremlinScala[JMap[String, AnyRef], Labels](traversal.valueMap(keys: _*))
 
-  def has(key: Key[_]) = GremlinScala[End, Labels](traversal.has(key.key))
+  def has(key: Key[_]) = GremlinScala[End, Labels](traversal.has(key.value))
 
-  def has[A](key: Key[A], value: A) = GremlinScala[End, Labels](traversal.has(key.key, value))
+  def has[A](key: Key[A], value: A) = GremlinScala[End, Labels](traversal.has(key.value, value))
 
-  def has[A](p: (Key[A], A)) = GremlinScala[End, Labels](traversal.has(p._1.key, p._2))
+  def has[A](p: (Key[A], A)) = GremlinScala[End, Labels](traversal.has(p._1.value, p._2))
 
-  def has[A](key: Key[A], predicate: P[A]) = GremlinScala[End, Labels](traversal.has(key.key, predicate))
+  def has[A](key: Key[A], predicate: P[A]) = GremlinScala[End, Labels](traversal.has(key.value, predicate))
 
   def has(accessor: T, value: Any) = GremlinScala[End, Labels](traversal.has(accessor, value))
 
@@ -338,25 +338,25 @@ class GremlinElementSteps[End <: Element, Labels <: HList](gremlinScala: Gremlin
 
   // A: type of the property value
   def has[A, B](key: Key[A], propertyTraversal: GremlinScala[A, HNil] ⇒ GremlinScala[B, _]) =
-    GremlinScala[End, Labels](traversal.has(key.key, propertyTraversal(start).traversal))
+    GremlinScala[End, Labels](traversal.has(key.value, propertyTraversal(start).traversal))
 
   def has[A](label: String, key: Key[A], value: A) =
-    GremlinScala[End, Labels](traversal.has(label, key.key, value))
+    GremlinScala[End, Labels](traversal.has(label, key.value, value))
 
   def has[A](label: String, key: Key[A], predicate: P[A]) =
-    GremlinScala[End, Labels](traversal.has(label, key.key, predicate))
+    GremlinScala[End, Labels](traversal.has(label, key.value, predicate))
 
   def hasId(ids: AnyRef*) = GremlinScala[End, Labels](traversal.hasId(ids: _*))
 
   def hasLabel(labels: String*) = GremlinScala[End, Labels](traversal.hasLabel(labels: _*))
 
-  def hasKey(keys: Key[_]*) = GremlinScala[End, Labels](traversal.hasKey(keys.map(_.key): _*))
+  def hasKey(keys: Key[_]*) = GremlinScala[End, Labels](traversal.hasKey(keys.map(_.value): _*))
 
   def hasValue(values: String*) = GremlinScala[End, Labels](traversal.hasValue(values: _*))
 
-  def hasNot(key: Key[_]) = GremlinScala[End, Labels](traversal.hasNot(key.key))
+  def hasNot(key: Key[_]) = GremlinScala[End, Labels](traversal.hasNot(key.value))
 
-  def hasNot[A](key: Key[A], value: A) = GremlinScala[End, Labels](traversal.not(__.has(key.key, value)))
+  def hasNot[A](key: Key[A], value: A) = GremlinScala[End, Labels](traversal.not(__.has(key.value, value)))
 
   def and(traversals: (GremlinScala[End, HNil] ⇒ GremlinScala[End, _])*) =
     GremlinScala[End, Labels](traversal.and(traversals.map {

--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -15,7 +15,6 @@ import org.apache.tinkerpop.gremlin.structure.{ T, Direction }
 import shapeless.{ HList, HNil, :: }
 import shapeless.ops.hlist.Prepend
 import scala.language.existentials
-import schema.Key
 
 case class GremlinScala[End, Labels <: HList](traversal: GraphTraversal[_, End]) {
   def toStream(): JStream[End] = traversal.toStream

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaEdge.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaEdge.scala
@@ -2,7 +2,6 @@ package gremlin.scala
 
 import shapeless._
 import scala.collection.JavaConversions._
-import schema.Key
 
 case class ScalaEdge(edge: Edge) extends ScalaElement[Edge] {
   override def element = edge

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaEdge.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaEdge.scala
@@ -8,7 +8,7 @@ case class ScalaEdge(edge: Edge) extends ScalaElement[Edge] {
   override def element = edge
 
   override def setProperty[A](key: Key[A], value: A): Edge = {
-    element.property(key.key, value)
+    element.property(key.value, value)
     edge
   }
 
@@ -40,7 +40,7 @@ case class ScalaEdge(edge: Edge) extends ScalaElement[Edge] {
   override def start() = GremlinScala[Edge, HNil](__(edge))
 
   override def properties[A: DefaultsToAny]: Stream[Property[A]] =
-    edge.properties[A](keys.map(_.key).toSeq: _*).toStream
+    edge.properties[A](keys.map(_.value).toSeq: _*).toStream
 
   override def properties[A: DefaultsToAny](wantedKeys: String*): Stream[Property[A]] =
     edge.properties[A](wantedKeys: _*).toStream

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
@@ -2,7 +2,6 @@ package gremlin.scala
 
 import scala.collection.JavaConversions._
 import shapeless._
-import schema.Key
 
 trait ScalaElement[ElementType <: Element] {
   def element: ElementType

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
@@ -23,7 +23,7 @@ trait ScalaElement[ElementType <: Element] {
 
   def removeProperties(keys: Key[_]*): ElementType
 
-  def property[A](key: Key[A]): Property[A] = element.property[A](key.key)
+  def property[A](key: Key[A]): Property[A] = element.property[A](key.value)
 
   def properties[A: DefaultsToAny]: Stream[Property[A]]
 
@@ -36,13 +36,13 @@ trait ScalaElement[ElementType <: Element] {
   // typesafe version of `value. have to call it `value2` because of a scala compiler bug :(
   // https://issues.scala-lang.org/browse/SI-9523
   def value2[A](key: Key[A]): A =
-    element.value[A](key.key)
+    element.value[A](key.value)
 
   // note: this may throw an IllegalStateException - better use `Property`
   def values[A: DefaultsToAny](keys: String*): Iterator[A] =
     element.values[A](keys: _*)
 
-  def valueMap[A: DefaultsToAny]: Map[String, A] = valueMap[A](keys.toSeq.map(_.key): _*)
+  def valueMap[A: DefaultsToAny]: Map[String, A] = valueMap[A](keys.toSeq.map(_.value): _*)
 
   def valueMap[A: DefaultsToAny](keys: String*): Map[String, A] =
     (properties[A](keys: _*) map (p ⇒ (p.key, p.value))).toMap

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaGraph.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaGraph.scala
@@ -47,7 +47,7 @@ case class ScalaGraph[G <: Graph](graph: G) {
   def +(label: String): Vertex = addVertex(label)
 
   def +(label: String, properties: (Key[_], Any)*): Vertex =
-    addVertex(label, properties.toMap.map { case (k, v) ⇒ (k.key, v) })
+    addVertex(label, properties.toMap.map { case (k, v) ⇒ (k.value, v) })
 
   // get vertex by id
   def v(id: Any): Option[Vertex] =

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaGraph.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaGraph.scala
@@ -7,7 +7,6 @@ import org.apache.tinkerpop.gremlin.structure.Graph.Variables
 import org.apache.tinkerpop.gremlin.structure.{Transaction, T}
 import shapeless._
 import scala.collection.JavaConversions._
-import schema._
 
 case class ScalaGraph[G <: Graph](graph: G) {
 

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -15,7 +15,7 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
     implicitly[Marshallable[P]].toCC(vertex.id, vertex.valueMap)
 
   override def setProperty[A](key: Key[A], value: A): Vertex = {
-    element.property(key.key, value)
+    element.property(key.value, value)
     vertex
   }
 
@@ -62,7 +62,7 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   def addEdge(label: String,
               inVertex: Vertex,
               properties: Map[Key[_], Any] = Map.empty): Edge = {
-    val params = properties.toSeq.flatMap(pair ⇒ Seq(pair._1.key, pair._2.asInstanceOf[AnyRef]))
+    val params = properties.toSeq.flatMap(pair ⇒ Seq(pair._1.value, pair._2.asInstanceOf[AnyRef]))
     vertex.addEdge(label, inVertex.vertex, params: _*)
   }
 
@@ -100,7 +100,7 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
     vertex.property(cardinality, key, value, keyValues: _*)
 
   override def properties[A: DefaultsToAny]: Stream[VertexProperty[A]] =
-    vertex.properties[A](keys.map(_.key).toSeq: _*).toStream
+    vertex.properties[A](keys.map(_.value).toSeq: _*).toStream
 
   override def properties[A: DefaultsToAny](wantedKeys: String*): Stream[VertexProperty[A]] =
     vertex.properties[A](wantedKeys: _*).toStream

--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -6,7 +6,6 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
 import org.apache.tinkerpop.gremlin.structure.{Direction, VertexProperty, T}
 import shapeless._
 import scala.collection.JavaConversions._
-import schema.Key
 
 case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   override def element = vertex

--- a/gremlin-scala/src/main/scala/gremlin/scala/Schema.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/Schema.scala
@@ -1,0 +1,4 @@
+package gremlin.scala
+
+// a type safe key for a property of a vertex/edge
+case class Key[A](value: String)

--- a/gremlin-scala/src/main/scala/gremlin/scala/SemiEdge.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/SemiEdge.scala
@@ -1,7 +1,5 @@
 package gremlin.scala
 
-import schema.Key
-
 case class SemiEdge(from: Vertex, label: String, properties: Map[Key[_], Any] = Map.empty) {
   def -->(to: Vertex) = from.asScala.addEdge(label, to, properties)
 }

--- a/gremlin-scala/src/main/scala/gremlin/scala/package.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/package.scala
@@ -7,7 +7,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.structure
 import org.apache.tinkerpop.gremlin.structure.VertexProperty
 import shapeless._
-import gremlin.scala.schema.Key
 
 import _root_.scala.language.implicitConversions
 import _root_.scala.reflect.runtime.universe._

--- a/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
@@ -1,22 +1,23 @@
 package gremlin.scala
 
-import org.apache.tinkerpop.gremlin.structure._
+// import org.apache.tinkerpop.gremlin.structure._
 
-import scala.language.implicitConversions
+// import scala.language.implicitConversions
 
 object schema {
   /**
     * Smaller than an Element, consisting of the particles used
     * compose a Property (or VertexProperty) of an Element (Edge or Vertex)
     */
-  sealed abstract class Atom[A](val key: String) {
-    def apply(n: A): (String, A) = key → n
-  }
+  // sealed abstract class Atom[A](val key: String) {
+  //   def apply(n: A): (String, A) = key → n
+  // }
 
-  case class Key[A](override val key: String) extends Atom[A](key)
+  case class Key[A](key: String)
+  // case class Key[A](override val key: String) extends Atom[A](key)
 
-  implicit class AtomValue[A](p: (String, A)) {
-    def key: String = p._1
-    def value: A = p._2
-  }
+  // implicit class AtomValue[A](p: (String, A)) {
+  //   def key: String = p._1
+  //   def value: A = p._2
+  // }
 }

--- a/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
@@ -15,8 +15,6 @@ object schema {
 
   case class Key[A](override val key: String) extends Atom[A](key)
 
-  object ID extends Atom[Any](T.id.name)
-
   implicit class AtomValue[A](p: (String, A)) {
     def key: String = p._1
     def value: A = p._2

--- a/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
@@ -15,8 +15,6 @@ object schema {
 
   case class Key[A](override val key: String) extends Atom[A](key)
 
-  object Label extends Atom[String](T.label.name)
-
   object ID extends Atom[Any](T.id.name)
 
   implicit class AtomValue[A](p: (String, A)) {

--- a/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
@@ -1,23 +1,5 @@
 package gremlin.scala
 
-// import org.apache.tinkerpop.gremlin.structure._
-
-// import scala.language.implicitConversions
-
 object schema {
-  /**
-    * Smaller than an Element, consisting of the particles used
-    * compose a Property (or VertexProperty) of an Element (Edge or Vertex)
-    */
-  // sealed abstract class Atom[A](val key: String) {
-  //   def apply(n: A): (String, A) = key → n
-  // }
-
-  case class Key[A](key: String)
-  // case class Key[A](override val key: String) extends Atom[A](key)
-
-  // implicit class AtomValue[A](p: (String, A)) {
-  //   def key: String = p._1
-  //   def value: A = p._2
-  // }
+  case class Key[A](value: String)
 }

--- a/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/schema.scala
@@ -1,5 +1,0 @@
-package gremlin.scala
-
-object schema {
-  case class Key[A](value: String)
-}

--- a/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala
@@ -2,7 +2,6 @@ package gremlin.scala
 
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import org.scalatest.{ FunSpec, Matchers }
-import schema.Key
 
 class ArrowSyntaxSpec extends FunSpec with Matchers {
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
@@ -3,7 +3,6 @@ package gremlin.scala
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import org.scalatest.matchers.ShouldMatchers
 import org.apache.tinkerpop.gremlin.structure.T
-import schema.Key
 import TestGraph._
 
 class ElementSpec extends TestBase {

--- a/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ElementSpec.scala
@@ -98,7 +98,7 @@ class ElementSpec extends TestBase {
       val label1 = "label1"
       val label2 = "label2"
       val v1 = graph.addVertex(label1)
-      val v2 = graph.addVertex(label2, Map(TestProperty.key → "testValue"))
+      val v2 = graph.addVertex(label2, Map(TestProperty.value → "testValue"))
 
       graph.V.has(T.label, label1).head shouldBe v1.vertex
       graph.V.has(T.label, label2).head shouldBe v2.vertex
@@ -139,7 +139,7 @@ class ElementSpec extends TestBase {
       val e = v1.asScala.addEdge("testLabel", v2, Map(TestProperty → "testValue"))
       e.label shouldBe "testLabel"
       e.value2(TestProperty) shouldBe "testValue"
-      e.valueMap(TestProperty.key) shouldBe Map(TestProperty.key → "testValue")
+      e.valueMap(TestProperty.value) shouldBe Map(TestProperty.value → "testValue")
       v1.outE().head shouldBe e.edge
       v1.out("testLabel").head shouldBe v2.vertex
     }

--- a/gremlin-scala/src/test/scala/gremlin/scala/GremlinStandardTestSuite.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/GremlinStandardTestSuite.scala
@@ -8,7 +8,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter._
 import org.apache.tinkerpop.gremlin.process.traversal.step.map._
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect._
 import org.apache.tinkerpop.gremlin.structure.T
-import schema.Key
 import TestGraph._
 
 import scala.collection.JavaConversions._

--- a/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
@@ -2,7 +2,6 @@ package gremlin.scala
 
 import java.time.LocalDateTime
 
-import gremlin.scala.schema._
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import org.scalatest.{WordSpec, Matchers}
 import collection.JavaConversions._

--- a/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/SchemaSpec.scala
@@ -9,37 +9,12 @@ import collection.JavaConversions._
 import shapeless.test.illTyped
 
 class SchemaSpec extends WordSpec with Matchers {
-  "a schema with a sequence of Atoms that apply a value to build a Tuple2" can {
-    "use some default atoms" in {
-      Label("software") shouldBe "label" → "software"
-      ID(1) shouldBe "id" → 1
-
-      Label("software") shouldBe Label.key → "software"
-      ID(1) shouldBe ID.key → 1
-    }
-
-    "use extension points to add new Atom definitions" in {
-      object Created extends Key[LocalDateTime]("created")
-      val now = LocalDateTime.now()
-      Created(now) shouldBe "created" → now
-      Created(now) shouldBe Created.key → now
-
-      object Name extends Key[String]("name")
-      Name("Daniel") shouldBe "name" → "Daniel"
-      Name("Daniel") shouldBe Name.key → "Daniel"
-
-      val Software = Label("software")
-      Software shouldBe Label.key → "software"
-      Software shouldBe Label.key → Software.value
-    }
-  }
-
   "a schema with defined Atoms" can {
-    val Software = Label("software").value
-    val Person = Label("person").value
-    val Paris = Label("Paris").value
-    val London = Label("London").value
-    val EuroStar = Label("eurostar").value
+    val Software = "software"
+    val Person = "person"
+    val Paris = "Paris"
+    val London = "London"
+    val EuroStar = "eurostar"
     object Name extends Key[String]("name")
     object Created extends Key[Int]("created")
     object Type extends Key[String]("type")
@@ -188,7 +163,7 @@ class SchemaSpec extends WordSpec with Matchers {
       }
 
       trait Fixture {
-        val City = Label("city").value
+        val City = "city"
         object Name extends Key[String]("name")
         object Population extends Key[Int]("population")
         object Distance extends Key[Int]("distance")

--- a/gremlin-scala/src/test/scala/gremlin/scala/TestBase.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TestBase.scala
@@ -4,7 +4,6 @@ import org.apache.tinkerpop.gremlin.structure._
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.scalatest.Matchers
 import org.scalatest.FunSpec
-import schema.Key
 
 trait TestGraph {
   val graph = TinkerFactory.createClassic().asScala


### PR DESCRIPTION
@dkrieg @joan38 while I love the new syntax to add vertices/edges with properties, I found the way it's built on top of atoms a bit too complex. So I removed them. It's simpler and we still get the same functionality - aside from creating more Atoms, which IMHO we don't really need. Any thoughts?