### PR TITLE
Upgrade shapeless to 2.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ val commonSettings = Seq(
       "org.apache.tinkerpop" % "tinkergraph-gremlin" % gremlinVersion exclude("org.slf4j", "slf4j-log4j12"),
       "org.scala-lang" % "scala-reflect" % scalaVersion,
       "com.novocode" % "junit-interface" % "0.11" % "test->default",
-      "com.chuusai" %% "shapeless" % "2.2.5",
-      "org.scala-lang.modules" %% "scala-xml" % "1.0.4", //just specified to eliminate sbt warnings
+      "com.chuusai" %% "shapeless" % "2.3.0",
+      "org.scala-lang.modules" %% "scala-xml" % "1.0.5", //just specified to eliminate sbt warnings
       "org.apache.tinkerpop" % "gremlin-test" % gremlinVersion % Test,
       "junit" % "junit" % "4.12" % Test,
       "org.scalatest" %% "scalatest" % "2.2.5" % Test


### PR DESCRIPTION
Shapeless 2.3 has just been released—lots of bugfixes and
enhancements without any breaking API changes:
http://milessabin.com/blog/2016/02/25/shapeless-2.3.0/

Also bumped the patch version of scala-xml. It was the only thing left
depending on scala-library <2.11.7, so bumping it cleans up all eviction
notices.