### PR TITLE
Fix for ClassCastException when using `order().by(...)`

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -183,7 +183,7 @@ case class GremlinScala[End, Labels <: HList](traversal: GraphTraversal[_, End])
     implicit ev: End <:< Element): GremlinScala[End, Labels] =
     GremlinScala[End, Labels](traversal.order().by(elementPropertyKey, comparator))
 
-  def order() = GremlinScala[End, Labels](traversal.order().by(Order.incr))
+  def order() = GremlinScala[End, Labels](traversal.order())
 
   def order(comparator: Order) = GremlinScala[End, Labels](traversal.order().by(comparator))
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -162,6 +162,14 @@ class TraversalSpec extends WordSpec with Matchers {
         .toList shouldBe Seq(35, 32, 29, 27)
     }
 
+    "order with sub-by" in new Fixture {
+      graph.V.has(Age).has(Name)
+        .order()
+        .by(Age.value, Order.incr)
+        .by(Name.value, Order.decr)
+        .toList shouldBe Seq.empty
+    }
+
     // TODO: does not work because tinkerpop's Order.java enforces to be on Object, and that's because it's an enum in java can't take type parameters
     // "allow primitive types" in new Fixture {
     //     graph.V.has(Age)

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -167,7 +167,8 @@ class TraversalSpec extends WordSpec with Matchers {
         .order()
         .by(Age.value, Order.incr)
         .by(Name.value, Order.decr)
-        .toList shouldBe Seq.empty
+        .value(Name)
+        .toList shouldBe Seq("vadas", "marko", "josh", "peter")
     }
 
     // TODO: does not work because tinkerpop's Order.java enforces to be on Object, and that's because it's an enum in java can't take type parameters


### PR DESCRIPTION
From the best I can tell, introducing a default ordering is the cause of the bug, given that vertexes and edges don't have an implicit ordering. Not sure what the broader implications are of making this change.