### PR TITLE
Added ability to update a vertex with a case class

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -13,6 +13,13 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   def toCC[CC <: Product: Marshallable] =
     implicitly[Marshallable[CC]].toCC(vertex.id, vertex.valueMap)
 
+  def updateWith[CC <: Product: Marshallable](update: CC) = {
+    val propMap = implicitly[Marshallable[CC]].fromCC(update).valueMap
+    propMap foreach {case (prop, value) => element.property(prop, value)}
+
+    vertex
+  }
+
   override def setProperty[A](key: Key[A], value: A): Vertex = {
     element.property(key.value, value)
     vertex

--- a/gremlin-scala/src/test/scala/gremlin/scala/MarshallableSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/MarshallableSpec.scala
@@ -14,6 +14,7 @@ case class CCWithOptionValueClass(s: String, i: Option[MyValueClass])
 case class CCWithOption(i: Int, s: Option[String])
 
 case class CCWithOptionId(s: String, @id id: Option[Int])
+case class CCWithOptionIdNested(s: String, @id id: Option[Int], i: MyValueClass)
 
 @label("label_a")
 case class CCWithLabel(s: String)
@@ -180,6 +181,18 @@ class MarshallableSpec extends WordSpec with Matchers {
     val ccWithLabelVertices = graph.V.hasLabel[CCWithLabel].toList
     ccWithLabelVertices should have size 1
     ccWithLabelVertices.head.toCC[CCWithLabel] shouldBe ccWithLabel
+  }
+
+  "update vertex via a case class" in new Fixture {
+    type CC = CCWithOptionIdNested
+    val ccInitial = CCWithOptionIdNested("string", None, MyValueClass(42))
+
+    val ccWithIdSet = (graph + ccInitial).toCC[CC]
+    val ccUpdate = ccWithIdSet.copy(s = "otherString", i = MyValueClass(7))
+
+    graph.V(ccWithIdSet.id.get).head.updateWith(ccUpdate).toCC[CC] shouldBe ccUpdate
+
+    graph.V(ccWithIdSet.id.get).head.toCC[CC] shouldBe ccUpdate
   }
 
   trait Fixture {


### PR DESCRIPTION
For #156 . 

Went with `updateWith` since the method is not actually ensuring a 1:1 correspondence with a case class, it only uses the provided instance as a "template". For example, it's entirely possible to apply `updateWith` on the same vertex using two case classes of different types - although no idea why'd one want that :).

On the other hand, this also allows for fail-safe handling of changes within your data model (e.g. new fields).

Tried to emulate the style. Went with a single, corner-case full test case, since we're not actually testing serialization _per se_, only its "derivative" use.