### PR TITLE
Bumped to 3.2.1 upstream.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val commonSettings = Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
 
   libraryDependencies <++= scalaVersion { scalaVersion =>
-    val gremlinVersion = "3.2.0-incubating"
+    val gremlinVersion = "3.2.1"
     Seq(
       "org.apache.tinkerpop" % "gremlin-core" % gremlinVersion exclude("org.slf4j", "slf4j-log4j12"),
       "org.scala-lang" % "scala-reflect" % scalaVersion,

--- a/gremlin-scala/src/test/scala/gremlin/scala/GremlinStandardTestSuite.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/GremlinStandardTestSuite.scala
@@ -475,6 +475,10 @@ object Tests {
 
     override def get_g_V_out_aggregateXaX_path =
       graph.asScala.V.out.aggregate("a").path
+
+    override def get_g_V_hasLabelXpersonX_aggregateXxX_byXageX_capXxX_asXyX_selectXyX() =
+      graph.asScala.V.hasLabel("person").aggregate("x").by("age").cap("x").as("y").select("y")
+        .asInstanceOf[GremlinScala[JCollection[Integer], _]]
   }
 
   class ScalaCountTest extends CountTest with StandardTest {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.0.2-SNAPSHOT"
+version in ThisBuild := "3.2.1.0-SNAPSHOT"


### PR DESCRIPTION
Having double-checked the upgrade notes:
http://tinkerpop.apache.org/docs/3.2.1/upgrade/#_tinkerpop_3_2_1

it looks like the test suite change was the only one relevant to `gremlin-scala` itself. Also, I hope that I got the versioning correctly.