### PR TITLE
Add TraversalSource.withRemote for Remote Traversal Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ val commonSettings = Seq(
       "org.slf4j" % "slf4j-nop" % "1.7.25" % Test,
       "org.apache.tinkerpop" % "tinkergraph-gremlin" % gremlinVersion % Test,
       "org.apache.tinkerpop" % "gremlin-test" % gremlinVersion % Test,
-      "org.scalatest" %% "scalatest" % "3.0.1" % Test
+      "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+      "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
   ),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalacOptions ++= Seq(

--- a/gremlin-scala/src/main/scala/gremlin/scala/TraversalSource.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/TraversalSource.scala
@@ -1,6 +1,9 @@
 package gremlin.scala
 
 import java.util.function.{ BinaryOperator, Supplier, UnaryOperator }
+
+import org.apache.commons.configuration.Configuration
+import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
 
 object TraversalSource {
@@ -34,4 +37,13 @@ case class TraversalSource(underlying: GraphTraversalSource) {
 
   def withSack[A](initialValue: A, splitOperator: A => A, mergeOperator: (A, A) => A): TraversalSource =
     withSack(() => initialValue, splitOperator, mergeOperator)
+
+  def withRemote(configFile: String): TraversalSource =
+    TraversalSource(underlying.withRemote(configFile))
+
+  def withRemote(configuration: Configuration): TraversalSource =
+    TraversalSource(underlying.withRemote(configuration))
+
+  def withRemote(connection: RemoteConnection): TraversalSource =
+    TraversalSource(underlying.withRemote(connection))
 }


### PR DESCRIPTION
To better facilitate RemoteConnection-based GraphTraversalSource
implementations, adds withRemote methods to TraversalSource.

See discussion in #118 for more details

