### PR TITLE
Allow V() to be used mid-traversal

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -673,6 +673,9 @@ case class GremlinScala[End, Labels <: HList](traversal: GraphTraversal[_, End])
   // NUMBER STEPS END
   // -------------------
 
+  def V(vertexIdsOrElements: Any*)(implicit ev: End <:< Vertex): GremlinScala[Vertex, Labels] =
+    GremlinScala[Vertex, Labels](traversal.V(vertexIdsOrElements.asInstanceOf[Seq[AnyRef]]: _*))
+
   // would rather use asJavaCollection, but unfortunately there are some casts to java.util.List in the tinkerpop codebase...
   protected def toJavaList[A](i: Iterable[A]): JList[A] = i.toList
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -581,6 +581,19 @@ class TraversalSpec extends WordSpec with Matchers {
     }
   }
 
+  "graph step" can {
+    "be used mid traversal" in new Fixture {
+      val a = StepLabel[Vertex]()
+      val b = StepLabel[Vertex]()
+      // visit marko (a), then vadas (b) and then connect the two
+      graph.V().has(Name, "marko").as(a).V().has(Name, "vadas").as(b).addE(Knows).from(a).to(b).property(StartTime, 2010).iterate
+
+      val names = graph.E().hasLabel(Knows).has(StartTime, 2010).bothV().value(Name).toList.sorted
+
+      names shouldEqual List("marko", "vadas")
+    }
+  }
+
   "time limit is honored" ignore new Fixture {
     val maxTime = FiniteDuration(50, MILLISECONDS)
     val start = System.currentTimeMillis
@@ -601,6 +614,8 @@ class TraversalSpec extends WordSpec with Matchers {
     val Nickname = Key[String]("nickname")
     val Lang = Key[String]("lang")
     val Age = Key[Int]("age")
+    val StartTime = Key[Int]("startTime")
+    val Knows = "knows"
     val Person = "person"
     val Created = "created"
   }

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -586,7 +586,10 @@ class TraversalSpec extends WordSpec with Matchers {
       val a = StepLabel[Vertex]()
       val b = StepLabel[Vertex]()
       // visit marko (a), then vadas (b) and then connect the two
-      graph.V().has(Name, "marko").as(a).V().has(Name, "vadas").as(b).addE(Knows).from(a).to(b).property(StartTime, 2010).iterate
+      graph.V().has(Name, "marko").as(a)
+        .V().has(Name, "vadas").as(b)
+        .addE(Knows).from(a).to(b).property(StartTime, 2010)
+        .iterate
 
       val names = graph.E().hasLabel(Knows).has(StartTime, 2010).bothV().value(Name).toList.sorted
 


### PR DESCRIPTION
The Graph step (V()) can be used mid-traversal (i.e.:
http://tinkerpop.apache.org/docs/current/reference/#graph-step).
Defining it in GremlinScala allows V() to be used in this way.

Noticed this while trying to connect two vertices with an edge using a traversal.