### PR TITLE
add `to` and `from` modulators that take traversals

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -303,9 +303,6 @@ case class GremlinScala[End, Labels <: HList](traversal: GraphTraversal[_, End])
 
   def identity() = GremlinScala[End, Labels](traversal.identity())
 
-  def to(direction: Direction, edgeLabels: String*) =
-    GremlinScala[Vertex, Labels](traversal.to(direction, edgeLabels: _*))
-
   def sideEffect(fun: End ⇒ Any) =
     GremlinScala[End, Labels](traversal.sideEffect(
       new JConsumer[Traverser[End]] {
@@ -716,10 +713,35 @@ case class GremlinScala[End, Labels <: HList](traversal: GraphTraversal[_, End])
   def addE(label: StepLabel[Vertex])(implicit ev: End <:< Vertex): GremlinScala[Edge, Labels] =
     GremlinScala[Edge, Labels](traversal.addE(label.name))
 
+  /* modulator, use in conjunction with simplePath(), cyclicPath(), path(), and addE()
+   * http://tinkerpop.apache.org/docs/current/reference/#from-step */
   def from(label: StepLabel[Vertex]): GremlinScala[End, Labels] =
     GremlinScala[End, Labels](traversal.from(label.name))
+
+  /* modulator, use in conjunction with simplePath(), cyclicPath(), path(), and addE()
+   * TODO: make this a standalone modulator like By that may only be used with the above mentioned steps
+   * note: when using with addE, it only selects the first vertex! 
+   * http://tinkerpop.apache.org/docs/current/reference/#from-step
+   * https://groups.google.com/forum/#!topic/gremlin-users/3YgKMKB4iNs */
+  def from(fromTraversal: GremlinScala[Vertex, _] => GremlinScala[Vertex, _]): GremlinScala[End, Labels] =
+    GremlinScala[End, Labels](traversal.from(fromTraversal(start).traversal.asInstanceOf[GraphTraversal[End, Vertex]]))
+
+  /* modulator, use in conjunction with simplePath(), cyclicPath(), path(), and addE()
+   * http://tinkerpop.apache.org/docs/current/reference/#from-step */
   def to(label: StepLabel[Vertex]): GremlinScala[End, Labels] =
     GremlinScala[End, Labels](traversal.to(label.name))
+
+  /* modulator, use in conjunction with simplePath(), cyclicPath(), path(), and addE()
+   * TODO: make this a standalone modulator like By that may only be used with the above mentioned steps
+   * note: when using with addE, it only selects the first vertex! 
+   * http://tinkerpop.apache.org/docs/current/reference/#from-step
+   * https://groups.google.com/forum/#!topic/gremlin-users/3YgKMKB4iNs */
+  def to(toTraversal: GremlinScala[Vertex, _] => GremlinScala[Vertex, _]): GremlinScala[End, Labels] =
+    GremlinScala[End, Labels](traversal.to(toTraversal(start).traversal.asInstanceOf[GraphTraversal[End, Vertex]]))
+
+  def to(direction: Direction, edgeLabels: String*) =
+    GremlinScala[Vertex, Labels](traversal.to(direction, edgeLabels: _*))
+
   // VERTEX STEPS END
   // -------------------
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -621,14 +621,32 @@ class TraversalSpec extends WordSpec with Matchers {
         graph.V(1).out(CoDeveloper).value(Name).toSet shouldBe Set("josh", "peter")
       }
 
+      "reference the `to` vertex via StepLabel" in new Fixture {
+        graph.V(1).as(v1Label).out(Created).in(Created).where(P.neq(v1Label.name)).addE(CoDeveloper).to(v1Label).iterate
+        graph.V(1).in(CoDeveloper).value(Name).toSet shouldBe Set("josh", "peter")
+      }
+
       "reference the `from` vertex via StepLabel" in new Fixture {
-        graph.V(1).as(v1Label).out(Created).in(Created).where(P.neq(v1Label.name)).addE(CoDeveloper).from(v1Label).iterate()
+        graph.V(1).as(v1Label).out(Created).in(Created).where(P.neq(v1Label.name)).addE(CoDeveloper).from(v1Label).iterate
         graph.V(1).out(CoDeveloper).value(Name).toSet shouldBe Set("josh", "peter")
       }
 
-      "reference the `to` vertex via StepLabel" in new Fixture {
-        graph.V(1).as(v1Label).out(Created).in(Created).where(P.neq(v1Label.name)).addE(CoDeveloper).to(v1Label).iterate()
-        graph.V(1).in(CoDeveloper).value(Name).toSet shouldBe Set("josh", "peter")
+      "reference the `to` vertex via traversal" in new Fixture {
+        val KnowsCreator = "knowsCreator"
+        graph.V(1).addE(KnowsCreator).to(_.out(Knows).out(Created)).iterate
+
+        // note: when using with addE, it only selects the first vertex! 
+        // https://groups.google.com/forum/#!topic/gremlin-users/3YgKMKB4iNs
+        graph.V(1).outE(KnowsCreator).count.head shouldBe 1
+      }
+
+      "reference the `from` vertex via traversal" in new Fixture {
+        val CreatorKnows = "creatorKnows"
+        graph.V(1).addE(CreatorKnows).from(_.out(Knows).out(Created)).iterate
+
+        // note: when using with addE, it only selects the first vertex! 
+        // https://groups.google.com/forum/#!topic/gremlin-users/3YgKMKB4iNs
+        graph.V(1).inE(CreatorKnows).count.head shouldBe 1
       }
     }
   }


### PR DESCRIPTION
note: when using with addE, it only selects the first vertex!
http://tinkerpop.apache.org/docs/current/reference/#from-step
https://groups.google.com/forum/#!topic/gremlin-users/3YgKMKB4iNs