### PR TITLE
Add limit(1) to head/headOption

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -68,9 +68,9 @@ class GremlinScala[End](val traversal: GraphTraversal[_, End]) {
   def toBuffer(): mutable.Buffer[End] = traversal.toList.asScala
 
   /** unsafe! this will throw a runtime exception if there is no element. better use `headOption` */
-  def head(): End = toList.head
+  def head(): End = limit(1).toList.head
 
-  def headOption(): Option[End] = toList.headOption
+  def headOption(): Option[End] = limit(1).toList.headOption
 
   def explain(): TraversalExplanation = traversal.explain()
 


### PR DESCRIPTION
This change ensures that head and headOption steps will limit
traversals to a single result, rather than executing a full traversal,
throwing away the tail, and then returning only the head.  This is
especially important when connecting to a remote GremlinServer, or
when a local Graph connects to a remote storage backend, where query
latencies can be quite large.