### PR TITLE
Fix GremlinScala.hasLabel[CC] w/ constant label

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,11 @@ inThisBuild(
 
 lazy val macros = project // macros must be in a separate compilation unit
   .in(file("macros"))
-  .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value
+    ))
 lazy val `gremlin-scala` = project.in(file("gremlin-scala")).dependsOn(macros)
 
 ThisBuild / publishTo := sonatypePublishTo.value

--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -793,23 +793,8 @@ class GremlinScala[End](val traversal: GraphTraversal[_, End]) {
 
   def hasLabel[CC <: Product: ru.WeakTypeTag]()(
       implicit ev: End <:< Element): GremlinScala.Aux[End, Labels] = {
-    val tpe = implicitly[ru.WeakTypeTag[CC]].tpe
-
-    // TODO: there must be a way to avoid this...
-    def unquote(s: String) = {
-      val quote = "\""
-      if (s.startsWith(quote) && s.endsWith(quote))
-        s.substring(1, s.length - 1)
-      else s
-    }
-
-    val label: String =
-      tpe.typeSymbol.asClass.annotations
-        .find { _.toString.startsWith("gremlin.scala.label(\"") }
-        .map(_.tree.children.tail.head.toString)
-        .map(unquote)
-        .getOrElse(tpe.typeSymbol.name.toString)
-
+    val label: String = Annotations.labelOf[CC].map(_.label)
+      .getOrElse(implicitly[ru.WeakTypeTag[CC]].tpe.typeSymbol.name.toString)
     hasLabel(label)
   }
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/marshallable/MarshallableSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/marshallable/MarshallableSpec.scala
@@ -36,6 +36,10 @@ case class CCWithNonOptionalUnderlyingShouldFail(@underlying underlying: Vertex)
 @label("label_a")
 case class CCWithLabel(s: String)
 
+object Labels { val refLabel = "label_b" }
+@label(Labels.refLabel)
+case class CCWithRefLabel(s: String)
+
 @label("the_label")
 case class ComplexCC(
     s: String,
@@ -211,12 +215,14 @@ class MarshallableSpec extends WordSpec with Matchers {
     val ccSimple = CCSimple("a string", 42)
     val ccWithOption = CCWithOption(52, Some("other string"))
     val ccWithLabel = CCWithLabel("s")
+    val ccWithRefLabel = CCWithRefLabel("z")
 
     graph + ccSimple
     graph + ccWithOption
     graph + ccWithLabel
+    graph + ccWithRefLabel
 
-    graph.V.count.head shouldBe 3
+    graph.V.count.head shouldBe 4
 
     val ccSimpleVertices = graph.V.hasLabel[CCSimple].toList
     (ccSimpleVertices should have).size(1)
@@ -225,6 +231,10 @@ class MarshallableSpec extends WordSpec with Matchers {
     val ccWithLabelVertices = graph.V.hasLabel[CCWithLabel].toList
     (ccWithLabelVertices should have).size(1)
     ccWithLabelVertices.head.toCC[CCWithLabel] shouldBe ccWithLabel
+
+    val ccWithRefLabelVertices = graph.V.hasLabel[CCWithRefLabel].toList
+    (ccWithRefLabelVertices should have).size(1)
+    ccWithRefLabelVertices.head.toCC[CCWithRefLabel] shouldBe ccWithRefLabel
   }
 
   "add edges using case-class".which {

--- a/macros/src/main/scala/gremlin/scala/Annotations.scala
+++ b/macros/src/main/scala/gremlin/scala/Annotations.scala
@@ -2,6 +2,9 @@ package gremlin.scala
 
 import scala.annotation.{compileTimeOnly, StaticAnnotation}
 import scala.annotation.meta._
+import scala.reflect.runtime.universe.runtimeMirror
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
 
 /** the underlying graph element, typically a vertex or edge */
 @getter @beanGetter
@@ -12,3 +15,43 @@ class underlying extends StaticAnnotation
 class id extends StaticAnnotation
 
 class label(val label: String = "") extends StaticAnnotation
+
+object Annotations {
+
+  private val mirror = runtimeMirror(getClass.getClassLoader)
+  private val toolbox = mirror.mkToolBox()
+
+  /**
+    * Extract a label annotation, and return an instance of that label
+    * @tparam T Target class
+    * @return
+    */
+  def labelOf[T: WeakTypeTag]: Option[label] = {
+    for (anno <- classAnnotations[T].find(_.tree.tpe =:= typeOf[label])) {
+      return Some(instantiate[label](anno))
+    }
+    None
+  }
+
+  /**
+    * Extract all class-level annotations from the given class
+    * @tparam T Target class
+    * @return
+    */
+  private def classAnnotations[T: WeakTypeTag]: List[Annotation] = {
+    weakTypeOf[T].typeSymbol.asClass.annotations
+  }
+
+  /**
+    * Given an annotation symbol, evaluate the annotation to instantiate and return an instance of it. The annotations
+    * retrieved with the reflection API are recorded compile-time AST structures as opposed to the materialized
+    * instances that Java's reflection API returns under runtime retention.
+    *
+    * @param annotation Annotation declaration
+    * @tparam T Expected annotation type
+    * @return
+    */
+  private def instantiate[T: TypeTag](annotation: Annotation): T = {
+    toolbox.eval(toolbox.untypecheck(annotation.tree)).asInstanceOf[T]
+  }
+}

--- a/macros/src/test/scala/gremlin/scala/AnnotationsSpec.scala
+++ b/macros/src/test/scala/gremlin/scala/AnnotationsSpec.scala
@@ -1,0 +1,32 @@
+package gremlin.scala
+
+import org.scalatest.{FunSpec, Matchers}
+
+case class CCWithoutLabel(foo: String)
+
+@label("com.example.CCWithLiteralLabel")
+case class CCWithLiteralLabel(foo: String)
+
+object VertexLabel { val CCWithRefLabel = "com.example.CCWithRefLabel" }
+@label(VertexLabel.CCWithRefLabel)
+case class CCWithRefLabel(foo: String)
+
+class AnnotationsSpec extends FunSpec with Matchers {
+
+  def toLabelString(label: Option[label]): String =
+    label.map(_.label).getOrElse(fail("Unable to locate a label"))
+
+  describe("labelOf") {
+    it("returns None for unlabeled classes") {
+      Annotations.labelOf[CCWithoutLabel] shouldBe None
+    }
+
+    it("returns the label for classes labeled with a literal string") {
+      toLabelString(Annotations.labelOf[CCWithLiteralLabel]) shouldBe "com.example.CCWithLiteralLabel"
+    }
+
+    it("returns the label for classes labeled indirectly with a constant string") {
+      toLabelString(Annotations.labelOf[CCWithRefLabel]) shouldBe VertexLabel.CCWithRefLabel
+    }
+  }
+}


### PR DESCRIPTION
In cases where a domain CC was labeled using a constant value, rather
than a simple literal string, GremlinScala.hasLabel[CC] would fail
to find the correct label, and would fall back to the class name.  This
change adds some utilities for resolving labels by CC, so that these
can be correctly resolved.

fixes #252