### PR TITLE
Minor traversal source/start fixes

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaElement.scala
@@ -9,7 +9,7 @@ trait ScalaElement[ElementType <: Element] {
   def graph: ScalaGraph = element.graph
 
   /** start a new traversal from this element */
-  def start(): GremlinScala.Aux[ElementType, HNil] = __(element)
+  def start(): GremlinScala.Aux[ElementType, HNil] = element.graph().inject(element)
 
   /** start a new traversal from this element and configure it */
   def start(configure: TraversalSource => TraversalSource): GremlinScala.Aux[ElementType, HNil] =

--- a/gremlin-scala/src/main/scala/gremlin/scala/TraversalSource.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/TraversalSource.scala
@@ -8,7 +8,7 @@ import shapeless.HNil
 
 object TraversalSource {
   def apply(graph: Graph): TraversalSource =
-    TraversalSource(new GraphTraversalSource(graph))
+    TraversalSource(graph.traversal())
 }
 
 case class TraversalSource(underlying: GraphTraversalSource) {


### PR DESCRIPTION
* Use inject when starting a traversal from an element rather than an
  anonymous traversal. Initializing a traversal in this manner maintains
  a reference to the element's graph, which allows for using steps that
  mutate the graph (e.g. adding a vertex or edge). An anonymous
  traversal's graph is EmptyGraph, which is immutable.
* Use underlying graph's traversal source when initializing a
  gremlin-scala TraversalSource. Supports use cases where the underlying
  graph provides a custom GraphTraversalSource implementation.