### PR TITLE
Fix Marshallable's fromCC

### DIFF
--- a/macros/src/main/scala/gremlin/scala/Marshallable.scala
+++ b/macros/src/main/scala/gremlin/scala/Marshallable.scala
@@ -194,11 +194,10 @@ object Marshallable {
               this.FromCC(
                 $idParam,
                 $label,
-                _root_.scala.collection.immutable.List(..$fromCCParams)
+                _root_.scala.collection.immutable.List[_root_.scala.collection.immutable.List[(_root_.scala.Predef.String,_root_.scala.Any)]](..$fromCCParams)
                   .flatten
                   .filter { kv =>
-                    kv.isInstanceOf[Product2[_, _]] &&
-                    kv.asInstanceOf[Product2[_, _]]._2 != null
+                    _root_.scala.Option(kv._2).isDefined
                   }
               )
             def toCC(element: _root_.gremlin.scala.Element): $tpe = $companion(..$toCCParams)


### PR DESCRIPTION
This brings back a fix that was removed in 3.3.4.7 to avoid compiler warnings when a property value's type cannot be null.

Since updating to 3.3.4.7, we've also been seeing dead code errors after calls to the DSL's select step. This PR also addresses this issue. Unfortunately, I have not yet been able to get a simple reproducible example together to contribute to DSLSpec, however it would appear to also be related to the fix for #265.  Fundamentally, the problem in #265 occurs when fromCCParams is empty. When the empty fromCCParams gets spliced into immutable.List.apply, the type of the resulting List is `List[Nothing]` (hence the _2 is not a member of Nothing errors).  Explicitly providing a type parameter to List fixes the issues.