### PR TITLE
Add type safe projection

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -126,16 +126,16 @@ class GremlinScala[End](val traversal: GraphTraversal[_, End]) {
       addBy: GraphTraversal[_, JMap[String, Any]] ⇒ GraphTraversal[_, JMap[String, Any]],
       buildResult: JMap[String, Any] ⇒ H) {
 
-    def apply[U, HR <: HList](f: GremlinScala[T] ⇒ GremlinScala[U])(
+    def apply[U, HR <: HList](by: By[U])(
         implicit prepend: Prepend.Aux[H, U :: HNil, HR]): ProjectionBuilder[T, HR] = {
       val label = UUID.randomUUID().toString
       new ProjectionBuilder[T, HR](labels :+ label,
-                                addBy.andThen(_.by(f(__[T]()).traversal)),
-                                map ⇒ buildResult(map) :+ map.get(label).asInstanceOf[U])
+                                   addBy.andThen(by.apply),
+                                   map ⇒ buildResult(map) :+ map.get(label).asInstanceOf[U])
     }
 
-    def and[U, HR <: HList](f: GremlinScala[T] ⇒ GremlinScala[U])(
-        implicit prepend: Prepend.Aux[H, U :: HNil, HR]): ProjectionBuilder[T, HR] = apply(f)
+    def and[U, HR <: HList](by: By[U])(
+        implicit prepend: Prepend.Aux[H, U :: HNil, HR]): ProjectionBuilder[T, HR] = apply(by)
 
     private[gremlin] def build(g: GremlinScala[T]): GremlinScala[H] = {
       GremlinScala(addBy(g.traversal.project(labels.head, labels.tail: _*))).map(buildResult)

--- a/gremlin-scala/src/test/scala/gremlin/scala/ProjectSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ProjectSpec.scala
@@ -2,7 +2,6 @@ package gremlin.scala
 
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.scalatest.{Matchers, WordSpec}
-import shapeless.HNil
 
 class ProjectSpec extends WordSpec with Matchers {
   def graph: ScalaGraph = TinkerFactory.createModern.asScala()
@@ -17,10 +16,10 @@ class ProjectSpec extends WordSpec with Matchers {
         .toList()
 
       result shouldBe List(
-        "lop" :: 3 :: HNil,
-        "lop" :: 3 :: HNil,
-        "lop" :: 3 :: HNil,
-        "ripple" :: 1 :: HNil
+        ("lop", 3),
+        ("lop",3),
+        ("lop",3),
+        ("ripple", 1)
       )
     }
 
@@ -32,7 +31,7 @@ class ProjectSpec extends WordSpec with Matchers {
           .and(By(__.inE().count())))
         .head()
 
-      result shouldBe (3 :: 0 :: HNil)
+      result shouldBe (3, 0)
     }
   }
 }

--- a/gremlin-scala/src/test/scala/gremlin/scala/ProjectSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ProjectSpec.scala
@@ -1,0 +1,38 @@
+package gremlin.scala
+
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
+import org.scalatest.{Matchers, WordSpec}
+import shapeless.HNil
+
+class ProjectSpec extends WordSpec with Matchers {
+  def graph: ScalaGraph = TinkerFactory.createModern.asScala()
+
+  "project steps" should {
+    "provide type safe result" in {
+      val result = graph
+        .V()
+        .out("created")
+        .project(_(_.value(Key[String]("name")))
+          .and(_.in("created").count()))
+        .toList()
+
+      result shouldBe List(
+        "lop" :: 3 :: HNil,
+        "lop" :: 3 :: HNil,
+        "lop" :: 3 :: HNil,
+        "ripple" :: 1 :: HNil
+      )
+    }
+
+    "provide other type safe result" in {
+      val result = graph
+        .V()
+        .has(Key("name").of("marko"))
+        .project(_(_.outE().count())
+          .and(_.inE().count()))
+        .head()
+
+      result shouldBe (3 :: 0 :: HNil)
+    }
+  }
+}

--- a/gremlin-scala/src/test/scala/gremlin/scala/ProjectSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/ProjectSpec.scala
@@ -12,8 +12,8 @@ class ProjectSpec extends WordSpec with Matchers {
       val result = graph
         .V()
         .out("created")
-        .project(_(_.value(Key[String]("name")))
-          .and(_.in("created").count()))
+        .project(_(By(Key[String]("name")))
+          .and(By(__.in("created").count())))
         .toList()
 
       result shouldBe List(
@@ -28,8 +28,8 @@ class ProjectSpec extends WordSpec with Matchers {
       val result = graph
         .V()
         .has(Key("name").of("marko"))
-        .project(_(_.outE().count())
-          .and(_.inE().count()))
+        .project(_(By(__.outE().count()))
+          .and(By(__.inE().count())))
         .head()
 
       result shouldBe (3 :: 0 :: HNil)


### PR DESCRIPTION
This PR adds type safe version of `project`. This uses a `ProjectionBuilder` class to build HList type. I choose to not expose projection label (only order of projections counts):
```scala
graph
        .V()
        .out("created")
        .project(_
          .apply(_.value(Key[String]("name")))
          .and(_.in("created").count()))
        .head()
// returns "lop" :: 3 :: HNil with correct type
```