### PR TITLE
Add getSideEffects Via Key Value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 private-key.pem
+.idea/

--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -154,6 +154,8 @@ class GremlinScala[End](val traversal: GraphTraversal[_, End]) {
 
   def loops() = GremlinScala[Integer, HNil](traversal.loops())
 
+  def getSideEffect[A](sideEffectKey: String): A = traversal.asAdmin().getSideEffects.get(sideEffectKey)
+
   def map[A](fun: End => A) =
     GremlinScala[A, Labels](traversal.map[A] { t: Traverser[End] =>
       fun(t.get)

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -5,8 +5,10 @@ import org.apache.tinkerpop.gremlin.structure.T
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import org.scalatest.{Matchers, WordSpec}
-import java.util.{List => JList, Map => JMap, Collection => JCollection}
+import java.util.{Collection => JCollection, List => JList, Map => JMap}
 import java.lang.{Long => JLong}
+
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalMetrics
 
 import scala.language.existentials
 import shapeless.test.illTyped
@@ -1013,6 +1015,21 @@ class TraversalSpec extends WordSpec with Matchers {
         .value(Age)
         .math("_ / x")
         .toSet shouldBe Set(2.9, 2.7, 3.2, 3.5)
+    }
+  }
+
+  "traversal getSideEffects".must {
+    val key = "Side Effect Key"
+
+    "return side effects if they exist" in new Fixture {
+      assertThrows[IllegalArgumentException] {
+        graph.V().getSideEffect(key)
+      }
+    }
+
+    "throw if side effects if no side effects in traversal" in new Fixture {
+      val profile: DefaultTraversalMetrics = graph.V().profile(key).getSideEffect(key)
+      assert(profile != null)
     }
   }
 


### PR DESCRIPTION
This is to address the issue here: https://github.com/mpollmeier/gremlin-scala/issues/280

This simply provides a wrapper which exposes the side effects of a traversal via the admin interface of the traversal. 