### PR TITLE
Cross-compile to 2.13.0 as well

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val gremlinVersion = "3.4.4"
 
 ThisBuild/organization := "com.michaelpollmeier"
 ThisBuild/scalaVersion := "2.13.1"
-ThisBuild/crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1")
+ThisBuild/crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0", "2.13.1")
 
 ThisBuild/libraryDependencies ++= Seq(
   "org.apache.tinkerpop" % "gremlin-core" % gremlinVersion,


### PR DESCRIPTION
When including `gremlin-scala` as a dependency I want to have an option
to include a version compiled to a specific Scala version.
Currently, including `gremlin-scala` means that `scala-reflect` 2.13.1
joins the party always which is not necessairly desired, due to binary
incompatibilities between 2.13.0 and 2.13.1.