### PR TITLE
Cross compile to a full Scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,9 +52,16 @@ Global/useGpgPinentry := true
 name := "root"
 publish / skip := true
 
+lazy val commonSettings = Seq(
+  crossVersion := CrossVersion.full,
+  crossTarget := target.value / s"scala-${scalaVersion.value}") // workaround for https://github.com/sbt/sbt/issues/5097
+
 lazy val macros = project // macros must be in a separate compilation unit
   .in(file("macros"))
+  .settings(commonSettings: _*)
   .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value)
-lazy val `gremlin-scala` = project.in(file("gremlin-scala")).dependsOn(macros)
+lazy val `gremlin-scala` = project.in(file("gremlin-scala"))
+  .dependsOn(macros)
+  .settings(commonSettings: _*)
 
 enablePlugins(GitVersioning)


### PR DESCRIPTION
Even though we have a number of Scala targets, they all compile to a
binary version, meaning 2.13.0 vs 2.13.1 is useless.

Added a workaround for that.