### PR TITLE
Handle Set properties in Marshallable

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,12 @@ YourKit is the creator of <a href="https://www.yourkit.com/java/profiler/">YourK
 <img src="doc/images/yourkit.png" height="44" />
 
 ### Breaking changes
+#### 3.4.7.2
+Marshallable now treats Sets as multi-properties, i.e. one property for each element in the set. This is similar to how
+List properties are handled and allows for a natural representation of vertex properties whose cardinality is `set`
+in case classes. This change breaks compatibility with Marshallable's previous behaviour in which Sets were effectively
+treated as `single` cardinality properties, i.e. a single property whose value is the entire set.
+
 #### 3.4.1.13
 The implementation for `@label` with non literal values (e.g. `@label(SomeClass.LABEL)`) was dropped due to it's [bad performance](https://github.com/mpollmeier/gremlin-scala/issues/288). Please use String literals instead, e.g. `@label("MyLabel")`.
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/marshallable/MarshallableSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/marshallable/MarshallableSpec.scala
@@ -27,6 +27,7 @@ case class CCWithOption(i: Int, s: Option[String])
 case class CCWithOptionValueClass(s: String, i: Option[MyValueClass])
 case class CCWithOptionAnyVal(x: Option[Int], y: Option[Long])
 case class CCWithList(s: String, ss: List[String], is: List[Int], ds: List[Double])
+case class CCWithSet(s: String, ss: Set[String])
 case class CCWithNullable(i: Int, @nullable maybeNull: String)
 
 case class CCWithOptionId(s: String, @id id: Option[Int])
@@ -147,6 +148,18 @@ class MarshallableSpec extends WordSpec with Matchers {
       val properties = vl.properties[String]("ss").asScala.toList
       properties.size shouldBe 2
       properties.map(_.value) shouldBe List("one", "two")
+    }
+
+    "handle Set members" in new Fixture {
+      val cc = CCWithSet(s = "foo", ss = Set("bar", "baz"))
+
+      val v = graph + cc
+      v.toCC[CCWithSet] shouldBe cc
+
+      val vl = graph.V(v.id).head
+      val properties = vl.properties[String]("ss").asScala.toList
+      properties.size shouldBe 2
+      properties.map(_.value) shouldBe List("bar", "baz")
     }
 
     "allows members to be `null` if annotated with `@nullable`" in new Fixture {

--- a/macros/src/main/scala/gremlin/scala/Marshallable.scala
+++ b/macros/src/main/scala/gremlin/scala/Marshallable.scala
@@ -122,6 +122,19 @@ object Marshallable {
             // _toCCParams :+ q"element.value[$returnType]($decoded)")
           }
 
+          def handleSetProperty = {
+            (_idParam,
+              _fromCCParams :+ q"cc.$name.toList.map { x => $decoded -> x }",
+              _toCCParams :+
+                q"""
+                    element.properties($decoded)
+                      .asScala
+                      .map(_.value)
+                      .toSet
+                      .asInstanceOf[$returnType]
+                  """)
+          }
+
           def valueGetter(tpe: Type): Option[MethodSymbol] =
             tpe.declarations.sorted
               .filter(_.isMethod)
@@ -177,6 +190,8 @@ object Marshallable {
               handleOptionProperty
             } else if (returnType.typeSymbol == weakTypeOf[List[_]].typeSymbol) {
               handleListProperty
+            } else if (returnType.typeSymbol == weakTypeOf[Set[_]].typeSymbol) {
+              handleSetProperty
             } else {
               handleStandardProperty(
                 nullable = field.annotations.map(_.tree.tpe).contains(weakTypeOf[nullable]))


### PR DESCRIPTION
This is a small change to Marshallable to handle Set properties. This gives us a natural way to represent vertex properties with `set` cardinality in case classes. Note that this is breaking change; the previous behaviour was to treat these as standard properties, i.e. `single` cardinality in which the value is the entire set object. 