### PR TITLE
Updates ScalaVertex.addEdge to accept implicit ScalaGraph

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/ScalaVertex.scala
@@ -73,7 +73,7 @@ case class ScalaVertex(vertex: Vertex) extends ScalaElement[Vertex] {
   def bothE(labels: String*) = start().bothE(labels: _*)
 
   /** `implicit ScalaGraph` required for configuration, e.g. when using remote graph */
-  def addEdge(label: String, inVertex: Vertex, properties: KeyValue[_]*): Edge =
+  def addEdge(label: String, inVertex: Vertex, properties: KeyValue[_]*)(implicit graph: ScalaGraph): Edge =
     graph.traversal.V(vertex).addE(label, properties: _*).to(inVertex).head
 
   def addEdge[CC <: Product: Marshallable](inVertex: Vertex, cc: CC): Edge = {


### PR DESCRIPTION
Updates ScalaVertex.addEdge to use a TraversalSource supplied via an
implicit ScalaGraph rather than creating a new default/unconfigured
TraversalSource on the underlying element's graph.