### PR TITLE
upgrade scala and sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 val gremlinVersion = "3.4.7"
 
 ThisBuild/organization := "com.michaelpollmeier"
-ThisBuild/scalaVersion := "2.13.3"
-ThisBuild/crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3")
+ThisBuild/scalaVersion := "2.13.5"
+ThisBuild/crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.5")
 
 ThisBuild/libraryDependencies ++= Seq(
   "org.apache.tinkerpop" % "gremlin-core" % gremlinVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.5.1


### PR DESCRIPTION
sbt < 1.5.1 will stop working in a few days due to the bintray sunset
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/