### PR TITLE
Fix typing bug of group(By(...), By(traversal))

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/GremlinScala.scala
@@ -425,7 +425,7 @@ class GremlinScala[End](val traversal: GraphTraversal[_, End]) {
   /** Organize objects in the stream into a Map, group keys and values with a modulator */
   def group[ModulatedKeys, ModulatedValues](keysBy: By[ModulatedKeys],
                                             valuesBy: By[ModulatedValues]) =
-    GremlinScala[JMap[ModulatedKeys, JCollection[ModulatedValues]], Labels](
+    GremlinScala[JMap[ModulatedKeys, valuesBy.ValueFold[ModulatedValues]], Labels](
       valuesBy(keysBy(traversal.group())))
 
   @deprecated("use group(by(...))", "3.0.0.1")

--- a/gremlin-scala/src/test/scala/gremlin/scala/SelectSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/SelectSpec.scala
@@ -4,7 +4,7 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import shapeless.{::, HNil}
-import java.util.{Collection => JCollection, Map => JMap}
+import java.util.{Map => JMap}
 import scala.collection.JavaConverters._
 
 class SelectSpec extends AnyWordSpec with Matchers {
@@ -161,7 +161,7 @@ class SelectSpec extends AnyWordSpec with Matchers {
         .V()
         .hasLabel("software")
         .group(By(__().value(Key[String]("name"))), By(__().in("created")))
-        .unfold[JMap.Entry[String, JCollection[Vertex]]]()
+        .unfold[JMap.Entry[String, Vertex]]()
         .selectKeys
         .toList()
       result shouldBe List("ripple", "lop")

--- a/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/TraversalSpec.scala
@@ -467,12 +467,11 @@ class TraversalSpec extends AnyWordSpec with Matchers {
     }
     "modulate key by label and value by traversal without folding" in new Fixture {
       type Label = String
-      type Name = String
-      private val results: JMap[Label, Name] =
-        graph.V().group(By.label, By(__[Vertex]().value(Name))).head()
+      private val results: JMap[Label, JLong] =
+        graph.V().group(By.label, By(__[Vertex]().value(Name).dedup().count())).head()
 
-      results.get("software") should be("lop").or(be("ripple"))
-      results.get("person") should be("marko").or(be("vadas")).or(be("josh")).or(be("peter"))
+      results.get("software") shouldBe 2L
+      results.get("person") shouldBe 4L
     }
     "modulate key by label and value by traversal with folding" in new Fixture {
       type Label = String


### PR DESCRIPTION
Although the group method is defined so that the type of `g.V().group(By.label,  By(__[Vertex]().count()).head().get("label")` becomes `JCollection[Long]`, the type at runtime is actually `Long`.