### PR TITLE
Feature/steps dsl extensions

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -98,6 +98,20 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def dedup(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.dedup())
 
+  /**
+    * The not step filters traversers where the provided sub-traversal produces results.
+    * This is the negation of a filter traversal.
+    */
+  def not(notTraversal: Steps[EndDomain, EndGraph, HNil] => Steps[_, _, _])
+    : Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](
+      raw.not { rawTraversal =>
+        notTraversal(
+          new Steps[EndDomain, EndGraph, HNil](rawTraversal)
+        ).raw
+      }
+    )
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -161,6 +161,12 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
       raw.coalesce[NewEndGraph](rawTraversals: _*))
   }
 
+  /** Unroll a collection or iterator into individual traversers. */
+  def unfold[NewEndDomain, NewEndGraph]()(
+      implicit newConverter: Converter.Aux[NewEndDomain, NewEndGraph])
+    : Steps[NewEndDomain, NewEndGraph, Labels] =
+    new Steps[NewEndDomain, NewEndGraph, Labels](raw.unfold[NewEndGraph]())
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -130,6 +130,10 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def barrier(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.barrier())
 
+  /** Filter out traversers that have visited the same element more than once (cyclic paths). */
+  def simplePath(): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.simplePath())
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -74,6 +74,12 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def count(): Long =
     raw.count().head()
 
+  /** Returns true if the traversal contains at least one element. */
+  def exists(): Boolean = headOption().isDefined
+
+  /** Returns true if the traversal contains no elements. */
+  def notExists(): Boolean = !exists()
+
   override def clone() = new Steps[EndDomain, EndGraph, Labels](raw.clone())
 
   def dedup(): Steps[EndDomain, EndGraph, Labels] =

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -161,6 +161,23 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
       raw.coalesce[NewEndGraph](rawTraversals: _*))
   }
 
+  /**
+    * Execute the provided traversal in local scope.
+    * Operations within local scope apply per-element rather than across the full traversal.
+    */
+  def local[NewEndDomain, NewEndGraph](
+      localTraversal: Steps[EndDomain, EndGraph, HNil] => Steps[NewEndDomain, NewEndGraph, _])(
+      implicit
+      newConverter: Converter.Aux[NewEndDomain, NewEndGraph],
+      ev: EndGraph <:< Element)
+    : Steps[NewEndDomain, NewEndGraph, Labels] = {
+    val rawTraversal = (rawGs: GremlinScala.Aux[EndGraph, HNil]) =>
+      localTraversal(new Steps[EndDomain, EndGraph, HNil](rawGs))
+        .raw.asInstanceOf[GremlinScala[NewEndGraph]]
+    new Steps[NewEndDomain, NewEndGraph, Labels](
+      raw.local[NewEndGraph](rawTraversal))
+  }
+
   /** Unroll a collection or iterator into individual traversers. */
   def unfold[NewEndDomain, NewEndGraph]()(
       implicit newConverter: Converter.Aux[NewEndDomain, NewEndGraph])

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -162,6 +162,24 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   }
 
   /**
+    * Merge the results of multiple traversals into a single flat result set.
+    * All traversals must produce the same output type.
+    */
+  def unionFlat[NewEndDomain, NewEndGraph](
+      unionTraversals: (Steps[EndDomain, EndGraph, HNil] => Steps[NewEndDomain, NewEndGraph, _])*)(
+      implicit newConverter: Converter.Aux[NewEndDomain, NewEndGraph])
+    : Steps[NewEndDomain, NewEndGraph, Labels] = {
+    val rawTraversals = unionTraversals.map { unionTraversal =>
+      (rawTraversal: GremlinScala.Aux[EndGraph, HNil]) =>
+        unionTraversal(
+          new Steps[EndDomain, EndGraph, HNil](rawTraversal)
+        ).raw.asInstanceOf[GremlinScala[NewEndGraph]]
+    }
+    new Steps[NewEndDomain, NewEndGraph, Labels](
+      raw.unionFlat[NewEndGraph](rawTraversals: _*))
+  }
+
+  /**
     * Execute the provided traversal in local scope.
     * Operations within local scope apply per-element rather than across the full traversal.
     */

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -82,6 +82,10 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
 
   override def clone() = new Steps[EndDomain, EndGraph, Labels](raw.clone())
 
+  /** Filter to keep only the last element of the traversal. */
+  def tail(): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.tail)
+
   def dedup(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.dedup())
 

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -142,6 +142,25 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def loops(): Steps[Integer, Integer, Labels] =
     new Steps[Integer, Integer, Labels](raw.loops())(Converter.forInteger)
 
+  /**
+    * Evaluate the provided traversals in order and return the first non-empty result.
+    * Each traversal is a function from the current Steps to a new Steps with potentially
+    * different domain/graph types.
+    */
+  def coalesce[NewEndDomain, NewEndGraph](
+      coalesceTraversals: (Steps[EndDomain, EndGraph, HNil] => Steps[NewEndDomain, NewEndGraph, _])*)(
+      implicit newConverter: Converter.Aux[NewEndDomain, NewEndGraph])
+    : Steps[NewEndDomain, NewEndGraph, Labels] = {
+    val rawTraversals = coalesceTraversals.map { coalesceTraversal =>
+      (rawTraversal: GremlinScala.Aux[EndGraph, HNil]) =>
+        coalesceTraversal(
+          new Steps[EndDomain, EndGraph, HNil](rawTraversal)
+        ).raw.asInstanceOf[GremlinScala[NewEndGraph]]
+    }
+    new Steps[NewEndDomain, NewEndGraph, Labels](
+      raw.coalesce[NewEndGraph](rawTraversals: _*))
+  }
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -126,6 +126,10 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
     new Steps[EndDomain, EndGraph, Labels](
       raw.is(converter.toGraph(value).asInstanceOf[AnyRef]))
 
+  /** Insert a bulk-synchronization barrier into the traversal. */
+  def barrier(): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.barrier())
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -116,6 +116,11 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def hasId(ids: AnyRef*)(implicit ev: EndGraph <:< Element): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.hasId(ids: _*))
 
+  /** Filter elements by their label. */
+  def hasLabel(label: String, labels: String*)(
+      implicit ev: EndGraph <:< Element): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.hasLabel(label, labels: _*))
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -121,6 +121,11 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
       implicit ev: EndGraph <:< Element): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.hasLabel(label, labels: _*))
 
+  /** Filter traversers by value equality, converting the domain value to the graph type. */
+  def is(value: EndDomain): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](
+      raw.is(converter.toGraph(value).asInstanceOf[AnyRef]))
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -134,6 +134,10 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def simplePath(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.simplePath())
 
+  /** Remove traversed elements from the graph. */
+  def drop(): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.drop())
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -138,6 +138,10 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   def drop(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.drop())
 
+  /** Returns the number of loops the current traverser has gone through in a repeat step. */
+  def loops(): Steps[Integer, Integer, Labels] =
+    new Steps[Integer, Integer, Labels](raw.loops())(Converter.forInteger)
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -162,6 +162,30 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   }
 
   /**
+    * Group traversal results by a key traversal and a value traversal.
+    * The keysBy traversal determines the grouping key and the valuesBy traversal
+    * determines the grouped values. Note that TinkerPop's group step with a value-by
+    * modulator collects values into lists at runtime, but the static type reflects
+    * the raw map type to match actual runtime behavior.
+    */
+  def group[KeyDomain, KeyGraph, ValueDomain, ValueGraph](
+      keysBy: Steps[EndDomain, EndGraph, HNil] => Steps[KeyDomain, KeyGraph, _],
+      valuesBy: Steps[EndDomain, EndGraph, HNil] => Steps[ValueDomain, ValueGraph, _])(
+      implicit
+      keyConverter: Converter.Aux[KeyDomain, KeyGraph],
+      valueConverter: Converter.Aux[ValueDomain, ValueGraph])
+    : Steps[JMap[KeyGraph, ValueGraph], JMap[KeyGraph, ValueGraph], Labels] = {
+    val rawKeysBy = keysBy(
+      new Steps[EndDomain, EndGraph, HNil](__[EndGraph]())).raw
+    val rawValuesBy = valuesBy(
+      new Steps[EndDomain, EndGraph, HNil](__[EndGraph]())).raw
+    new Steps[JMap[KeyGraph, ValueGraph], JMap[KeyGraph, ValueGraph], Labels](
+      raw.group(keysBy = By(rawKeysBy), valuesBy = By(rawValuesBy))
+        .asInstanceOf[GremlinScala[JMap[KeyGraph, ValueGraph]]]
+    )(Converter.identityConverter)
+  }
+
+  /**
     * Filter the current traversal by a sub-traversal.
     * Only traversers for which the sub-traversal produces at least one result are kept.
     */

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -112,6 +112,10 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
       }
     )
 
+  /** Filter elements by their ID. */
+  def hasId(ids: AnyRef*)(implicit ev: EndGraph <:< Element): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.hasId(ids: _*))
+
   /* access all gremlin-scala methods that don't modify the EndGraph type, e.g. `has` */
   /* TODO: track/use NewLabelsGraph as given by `fun` */
   def onRaw(

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -4,6 +4,7 @@ import gremlin.scala._
 import gremlin.scala.StepLabel.{combineLabelWithValue, GetLabelName}
 import java.util.{Map => JMap}
 import java.util.stream.{Stream => JStream}
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import scala.collection.mutable
 import shapeless.{::, HList, HNil}
 import shapeless.ops.hlist.{IsHCons, Mapper, Prepend, RightFolder, ToTraversable, Tupler}
@@ -85,6 +86,14 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   /** Filter to keep only the last element of the traversal. */
   def tail(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.tail)
+
+  /** Limit the number of results to the given maximum. */
+  def limit(max: Long): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.limit(max))
+
+  /** Limit the number of results to the given maximum within the given scope. */
+  def limit(scope: Scope, max: Long): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.limit(scope, max))
 
   def dedup(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.dedup())

--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -162,6 +162,20 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
   }
 
   /**
+    * Filter the current traversal by a sub-traversal.
+    * Only traversers for which the sub-traversal produces at least one result are kept.
+    */
+  def where(whereTraversal: Steps[EndDomain, EndGraph, HNil] => Steps[_, _, _])
+    : Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](
+      raw.where { rawTraversal =>
+        whereTraversal(
+          new Steps[EndDomain, EndGraph, HNil](rawTraversal)
+        ).raw
+      }
+    )
+
+  /**
     * Merge the results of multiple traversals into a single flat result set.
     * All traversals must produce the same output type.
     */

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -257,6 +257,12 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size shouldBe 0
   }
 
+  "drop removes elements from the graph" in {
+    val graph = TinkerFactory.createModern
+    PersonSteps(graph).hasName("marko").drop().iterate()
+    PersonSteps(graph).hasName("marko").exists() shouldBe false
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -221,6 +221,14 @@ class DslSpec extends AnyWordSpec with Matchers {
     result shouldBe List(Person(Some(1), "marko", 29))
   }
 
+  "hasLabel filters by element label" in {
+    val graph = TinkerFactory.createModern
+    val result = new Steps[Vertex, Vertex, HNil](graph.V)(Converter.identityConverter)
+      .hasLabel("software")
+      .toList
+    result.size shouldBe 2
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -209,6 +209,13 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size shouldBe 2
   }
 
+  "not filters out matching traversals" in {
+    val result = PersonSteps(TinkerFactory.createModern)
+      .not(_.created.isRipple)
+      .toList
+    result.size shouldBe 3
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -273,6 +273,19 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size should be > 0
   }
 
+  "coalesce returns first non-empty traversal" in {
+    implicit val graph = TinkerFactory.createModern
+    // marko has no "created" with name "nonexistent", so first branch is empty
+    // second branch finds marko's created software
+    val result = PersonSteps(graph).hasName("marko")
+      .coalesce(
+        _.created.isRipple,  // marko didn't create ripple
+        _.created            // marko created lop
+      )
+      .toSet
+    result shouldBe Set(Software("lop", "java"))
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -216,6 +216,11 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size shouldBe 3
   }
 
+  "hasId filters by element id" in {
+    val result = PersonSteps(TinkerFactory.createModern).hasId(1: Integer).toList
+    result shouldBe List(Person(Some(1), "marko", 29))
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -183,6 +183,22 @@ class DslSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "exists returns true when traversal has results" in {
+    PersonSteps(TinkerFactory.createModern).exists() shouldBe true
+  }
+
+  "exists returns false when traversal has no results" in {
+    PersonSteps(TinkerFactory.createModern).hasName("nonexistent").exists() shouldBe false
+  }
+
+  "notExists returns true when traversal has no results" in {
+    PersonSteps(TinkerFactory.createModern).hasName("nonexistent").notExists() shouldBe true
+  }
+
+  "notExists returns false when traversal has results" in {
+    PersonSteps(TinkerFactory.createModern).notExists() shouldBe false
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -273,6 +273,15 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size should be > 0
   }
 
+  "where filters by sub-traversal" in {
+    val graph = TinkerFactory.createModern
+    // find persons who created ripple
+    val result = PersonSteps(graph)
+      .where(_.created.isRipple)
+      .toList
+    result shouldBe List(Person(Some(4), "josh", 32))
+  }
+
   "unionFlat merges results from multiple traversals" in {
     implicit val graph = TinkerFactory.createModern
     // union of two different person filters

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -199,6 +199,11 @@ class DslSpec extends AnyWordSpec with Matchers {
     PersonSteps(TinkerFactory.createModern).notExists() shouldBe false
   }
 
+  "tail returns last element" in {
+    val result = PersonSteps(TinkerFactory.createModern).tail().toList
+    result.size shouldBe 1
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -244,6 +244,19 @@ class DslSpec extends AnyWordSpec with Matchers {
     withBarrier shouldBe withoutBarrier
   }
 
+  "simplePath filters cyclic paths" in {
+    val graph = TinkerFactory.createModern
+    // marko -> knows -> josh/vadas, then back via knows -> marko/josh/vadas
+    // simplePath should filter out revisited vertices
+    val result = PersonSteps(graph).hasName("marko")
+      .onRaw(_.out("knows").out("knows"))
+      .simplePath()
+      .toList
+    // marko -> josh -> (no outgoing knows), marko -> vadas -> (no outgoing knows)
+    // all paths are simple since there are no cycles in 2-hop knows from marko
+    result.size shouldBe 0
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -273,6 +273,17 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size should be > 0
   }
 
+  "local executes traversal in local scope" in {
+    implicit val graph = TinkerFactory.createModern
+    // local limit(1) on created gives at most 1 software per person
+    val result = PersonSteps(graph)
+      .local(_.created.limit(1))
+      .toList
+    // each person gets at most 1 created software locally
+    result.size should be <= 4
+    result.size should be > 0
+  }
+
   "unfold unrolls folded results" in {
     val graph = TinkerFactory.createModern
     // fold names into a list, then unfold back

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -229,6 +229,15 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size shouldBe 2
   }
 
+  "is filters by value equality" in {
+    val graph = TinkerFactory.createModern
+    val result = new Steps[String, String, HNil](
+      graph.V.values[String]("name"))(Converter.identityConverter)
+      .is("marko")
+      .toList
+    result shouldBe List("marko")
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -204,6 +204,11 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size shouldBe 1
   }
 
+  "limit restricts number of results" in {
+    val result = PersonSteps(TinkerFactory.createModern).limit(2).toList
+    result.size shouldBe 2
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -273,6 +273,15 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size should be > 0
   }
 
+  "unfold unrolls folded results" in {
+    val graph = TinkerFactory.createModern
+    // fold names into a list, then unfold back
+    val names = new Steps[String, String, HNil](
+      graph.V.values[String]("name").fold().unfold[String]()
+    )(Converter.identityConverter).toList
+    names.size shouldBe 6
+  }
+
   "coalesce returns first non-empty traversal" in {
     implicit val graph = TinkerFactory.createModern
     // marko has no "created" with name "nonexistent", so first branch is empty

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -263,6 +263,16 @@ class DslSpec extends AnyWordSpec with Matchers {
     PersonSteps(graph).hasName("marko").exists() shouldBe false
   }
 
+  "loops returns loop count in repeat traversal" in {
+    implicit val graph = TinkerFactory.createModern
+    // Use repeat/until with loops to verify loops step works
+    val result = PersonSteps(graph).hasName("marko")
+      .repeat(_.onRaw(_.out("knows")))
+      .until(_.loops().is(1: Integer))
+      .toList
+    result.size should be > 0
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -273,6 +273,21 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size should be > 0
   }
 
+  "unionFlat merges results from multiple traversals" in {
+    implicit val graph = TinkerFactory.createModern
+    // union of two different person filters
+    val result = PersonSteps(graph)
+      .unionFlat(
+        _.hasName("marko"),
+        _.hasName("josh")
+      )
+      .toSet
+    result shouldBe Set(
+      Person(Some(1), "marko", 29),
+      Person(Some(4), "josh", 32)
+    )
+  }
+
   "local executes traversal in local scope" in {
     implicit val graph = TinkerFactory.createModern
     // local limit(1) on created gives at most 1 software per person

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -238,6 +238,12 @@ class DslSpec extends AnyWordSpec with Matchers {
     result shouldBe List("marko")
   }
 
+  "barrier does not change results" in {
+    val withBarrier = PersonSteps(TinkerFactory.createModern).barrier().toSet
+    val withoutBarrier = PersonSteps(TinkerFactory.createModern).toSet
+    withBarrier shouldBe withoutBarrier
+  }
+
   "allows to be cloned" in {
     val graph = TinkerFactory.createModern
     def personSteps = PersonSteps(graph)

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -273,6 +273,18 @@ class DslSpec extends AnyWordSpec with Matchers {
     result.size should be > 0
   }
 
+  "group groups by key and value traversals" in {
+    implicit val graph = TinkerFactory.createModern
+    // group persons by name, collecting the names of software they created
+    val result: JMap[String, String] = PersonSteps(graph)
+      .group(_.name, _.created.name)
+      .head()
+    val grouped = result.asScala
+    grouped should contain key "marko"
+    grouped should contain key "josh"
+    grouped should contain key "peter"
+  }
+
   "where filters by sub-traversal" in {
     val graph = TinkerFactory.createModern
     // find persons who created ripple
@@ -365,6 +377,9 @@ object TestDomain {
       extends NodeSteps[Software, Labels](raw) {
 
     def createdBy = new PersonSteps[Labels](raw.in("created"))
+
+    def name =
+      new Steps[String, String, Labels](raw.map(_.value[String]("name")))
 
     def isRipple = new SoftwareSteps[Labels](raw.has(Key("name") -> "ripple"))
   }


### PR DESCRIPTION
Adds 17 generic Gremlin traversal steps to the DSL Steps class. Each step is a thin, type-safe
wrapper that delegates to the underlying GremlinScala traversal while preserving the DSL's domain/graph type separation and converter mechanics.

Steps added
  exists / notExists Check whether the traversal contains any elements         
  tail               Keep only the last element                                
  limit              Restrict the number of results (global and scoped)        
  not                Filter out traversers matching a sub-traversal            
  hasId              Filter elements by ID                                     
  hasLabel           Filter elements by label                                  
  is                 Filter by value equality (domain-to-graph converted)      
  barrier            Insert a bulk-synchronization barrier                     
  simplePath         Filter out cyclic paths                                   
  drop               Remove traversed elements from the graph                  
  loops              Return the loop count within a repeat step                
  coalesce           Return the first non-empty result from ordered traversals 
  unfold             Unroll a collection into individual traversers            
  local              Execute a sub-traversal in per-element scope              
  unionFlat           Merge results from multiple traversals                    
  where               Filter by sub-traversal existence                         
  group              Group results by key and value traversals                 