### PR TITLE
Add tail(limit) and tail(scope, limit) overloads to DSL

### DIFF
--- a/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
+++ b/gremlin-scala/src/main/scala/gremlin/scala/dsl/Steps.scala
@@ -4,6 +4,7 @@ import gremlin.scala._
 import gremlin.scala.StepLabel.{combineLabelWithValue, GetLabelName}
 import java.util.{Map => JMap}
 import java.util.stream.{Stream => JStream}
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import scala.collection.mutable
 import shapeless.{::, HList, HNil}
 import shapeless.ops.hlist.{IsHCons, Mapper, Prepend, RightFolder, ToTraversable, Tupler}
@@ -76,6 +77,14 @@ class Steps[EndDomain, EndGraph, Labels <: HList](val raw: GremlinScala[EndGraph
 
   override def clone() = new Steps[EndDomain, EndGraph, Labels](raw.clone())
 
+  /** Filter to keep the last N elements of the traversal. */
+  def tail(limit: Long): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.tail(limit))
+
+  /** Filter to keep the last N elements of the traversal within the given scope. */
+  def tail(scope: Scope, limit: Long): Steps[EndDomain, EndGraph, Labels] =
+    new Steps[EndDomain, EndGraph, Labels](raw.tail(scope, limit))
+  
   def dedup(): Steps[EndDomain, EndGraph, Labels] =
     new Steps[EndDomain, EndGraph, Labels](raw.dedup())
 

--- a/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
+++ b/gremlin-scala/src/test/scala/gremlin/scala/dsl/DslSpec.scala
@@ -2,6 +2,7 @@ package gremlin.scala.dsl
 
 import gremlin.scala._
 import java.util.{Map => JMap}
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -181,6 +182,18 @@ class DslSpec extends AnyWordSpec with Matchers {
       val results: List[(String, Set[Software])] = query.toList()
       results.size shouldBe 4
     }
+  }
+
+  "tail(limit) returns last N elements" in {
+    val result = PersonSteps(TinkerFactory.createModern).tail(2).toList
+    result.size shouldBe 2
+  }
+
+  "tail(scope, limit) returns last N elements in given scope" in {
+    val graph = TinkerFactory.createModern
+    // Scope.global behaves the same as the unscoped tail(limit) variant
+    val result = PersonSteps(graph).tail(Scope.global, 2).toList
+    result.size shouldBe 2
   }
 
   "allows to be cloned" in {


### PR DESCRIPTION
Add parameterized tail step overloads to keep the last N elements of the traversal, both globally and within a given scope.